### PR TITLE
update xcode environment schema

### DIFF
--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -565,6 +565,7 @@ On Xcode toolbar go to `Product` > `Scheme` > `+Edit Scheme...+`, and in the `Ar
 
 * VK_ICD_FILENAMES = `vulkansdk/macOS/share/vulkan/icd.d/MoltenVK_icd.json`
 * VK_LAYER_PATH = `vulkansdk/macOS/share/vulkan/explicit_layer.d`
+* VK_DRIVER_FILES = `vulkansdk/macOS/share/vulkan/icd.d/MoltenVK_icd.json`
 
 It should look like so:
 


### PR DESCRIPTION
Rationale: 
if I'm using environment variables from the [official tutorial](https://docs.vulkan.org/tutorial/latest/02_Development_environment.html#_setting_up_xcode) in Xcode, the result is below. 

<img width="738" alt="Screenshot 2023-12-04 at 22 23 12" src="https://github.com/KhronosGroup/Vulkan-Tutorial/assets/150726378/48d656d0-4e2e-4b2d-be49-8c72848b2336">


```
required extensions:
1
	VK_KHR_portability_enumeration
available extensions:
4
	VK_EXT_debug_report
	VK_EXT_debug_utils
	VK_KHR_portability_enumeration
	VK_LUNARG_direct_driver_loading
-9
failed to create instance!
Program ended with exit code: 1
```

if I'm using the variable from the `setup-env.sh` from the VulkanSDK

<img width="734" alt="Screenshot 2023-12-04 at 22 23 26" src="https://github.com/KhronosGroup/Vulkan-Tutorial/assets/150726378/251bbff4-fbc6-462a-a127-55e3df899208">


```
required extensions:
3
	VK_KHR_surface
	VK_EXT_metal_surface
	VK_KHR_portability_enumeration
available extensions:
15
	VK_KHR_device_group_creation
	VK_KHR_external_fence_capabilities
	VK_KHR_external_memory_capabilities
	VK_KHR_external_semaphore_capabilities
	VK_KHR_get_physical_device_properties2
	VK_KHR_get_surface_capabilities2
	VK_KHR_surface
	VK_EXT_debug_report
	VK_EXT_debug_utils
	VK_EXT_metal_surface
	VK_EXT_surface_maintenance1
	VK_EXT_swapchain_colorspace
	VK_MVK_macos_surface
	VK_KHR_portability_enumeration
	VK_LUNARG_direct_driver_loading
Program ended with exit code: 0
```


Thoughts: 
- I was thinking about adding the whole list of environment variables from the `setup-env.sh` but not sure if needed. 

