### PR TITLE
Remove GLM_FORCE_RADIANS which is deprecated since glm 0.9.6.0 (2014-11-30)

### DIFF
--- a/attachments/22_descriptor_set_layout.cpp
+++ b/attachments/22_descriptor_set_layout.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -1,7 +1,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/glm.hpp>

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -4,7 +4,6 @@
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -91,7 +91,6 @@ We'll start from scratch in the next chapter.
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
@@ -290,7 +289,6 @@ We'll start from scratch in the next chapter.
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>
@@ -497,7 +495,6 @@ Now, let's change the code in the generated `main.cpp` file to the following cod
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/vec4.hpp>
 #include <glm/mat4x4.hpp>

--- a/en/05_Uniform_buffers/00_Descriptor_set_layout_and_buffer.adoc
+++ b/en/05_Uniform_buffers/00_Descriptor_set_layout_and_buffer.adoc
@@ -313,7 +313,6 @@ We need to include two new headers to implement this functionality:
 
 [,c++]
 ----
-#define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -321,7 +320,6 @@ We need to include two new headers to implement this functionality:
 ----
 
 The `glm/gtc/matrix_transform.hpp` header exposes functions that can be used to generate model transformations like `glm::rotate`, view transformations like `glm::lookAt` and projection transformations like `glm::perspective`.
-The `GLM_FORCE_RADIANS` definition is necessary to make sure that functions like `glm::rotate` use radians as arguments, to avoid any possible confusion.
 
 The `chrono` standard library header exposes functions to do precise timekeeping.
 We'll use this to make sure that the geometry rotates 90 degrees per second regardless of frame rate.

--- a/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.adoc
+++ b/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.adoc
@@ -323,7 +323,6 @@ We can define `GLM_FORCE_DEFAULT_ALIGNED_GENTYPES` right before including GLM:
 
 [,c++]
 ----
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEFAULT_ALIGNED_GENTYPES
 #include <glm/glm.hpp>
 ----

--- a/en/07_Depth_buffering.adoc
+++ b/en/07_Depth_buffering.adoc
@@ -108,7 +108,6 @@ It is possible to manipulate this value from the fragment shader, just like you 
 
 [,c++]
 ----
-#define GLM_FORCE_RADIANS
 #define GLM_FORCE_DEPTH_ZERO_TO_ONE
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
[GLM_FORCE_RADIANS deprecation](https://github.com/g-truc/glm?tab=readme-ov-file#deprecation-4)

This PR prevents people from copy-pasting the now useless GLM_FORCE_RADIANS definition.