### PR TITLE
Removed unnecessary variable

### DIFF
--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -341,7 +341,7 @@ private:
 
         VkSurfaceFormatKHR surfaceFormat = chooseSwapSurfaceFormat(swapChainSupport.formats);
         VkPresentModeKHR presentMode = chooseSwapPresentMode(swapChainSupport.presentModes);
-        VkExtent2D extent = chooseSwapExtent(swapChainSupport.capabilities);
+        swapChainExtent = chooseSwapExtent(swapChainSupport.capabilities);
 
         uint32_t imageCount = swapChainSupport.capabilities.minImageCount + 1;
         if (swapChainSupport.capabilities.maxImageCount > 0 && imageCount > swapChainSupport.capabilities.maxImageCount) {
@@ -355,7 +355,7 @@ private:
         createInfo.minImageCount = imageCount;
         createInfo.imageFormat = surfaceFormat.format;
         createInfo.imageColorSpace = surfaceFormat.colorSpace;
-        createInfo.imageExtent = extent;
+        createInfo.imageExtent = swapChainExtent;
         createInfo.imageArrayLayers = 1;
         createInfo.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
@@ -384,7 +384,6 @@ private:
         vkGetSwapchainImagesKHR(device, swapChain, &imageCount, swapChainImages.data());
 
         swapChainImageFormat = surfaceFormat.format;
-        swapChainExtent = extent;
     }
 
     void createImageViews() {

--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -165,6 +165,4 @@ vkGetDeviceQueue(device, indices.graphicsFamily.value(), 0, &graphicsQueue);
 With the logical device and queue handles we can now actually start using the graphics card to do things!
 In the xref:03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc[next few chapters] we'll set up the resources to present results to the window system.
 
-The next step is to xref:03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc[create a window surface].
-
 link:/attachments/04_logical_device.cpp[C{pp} code]

--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -165,4 +165,6 @@ vkGetDeviceQueue(device, indices.graphicsFamily.value(), 0, &graphicsQueue);
 With the logical device and queue handles we can now actually start using the graphics card to do things!
 In the next few chapters we'll set up the resources to present results to the window system.
 
+The next step is to xref:03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc[create a window surface].
+
 link:/attachments/04_logical_device.cpp[C{pp} code]


### PR DESCRIPTION
We already have a class variable "swapChainExtent". Local "extent" variable seems unnecessary since we throw an error if swapchain creation fails.