### PR TITLE
Fix Markdown typo in 02_Fixed_functions.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
@@ -61,7 +61,7 @@ The former is specified in the `topology` member and can have values like:
 * `VK_PRIMITIVE_TOPOLOGY_LINE_LIST`: line from every 2 vertices without reuse
 * `VK_PRIMITIVE_TOPOLOGY_LINE_STRIP`: the end vertex of every line is used as start vertex for the next line
 * `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST`: triangle from every 3 vertices without reuse
-* `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP `: the second and third vertex of every triangle are used as first two vertices of the next triangle
+* `VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP`: the second and third vertex of every triangle are used as first two vertices of the next triangle
 
 Normally, the vertices are loaded from the vertex buffer by index in sequential order, but with an _element buffer_ you can specify the indices to use yourself.
 This allows you to perform optimizations like reusing vertices.


### PR DESCRIPTION
Remove an extra space which is the result of a typo.