### PR TITLE
Fix broken links

### DIFF
--- a/en/00_Introduction.adoc
+++ b/en/00_Introduction.adoc
@@ -129,8 +129,7 @@ certain Vulkan feature.
 That means that the site is also useful as a reference.
 All the Vulkan functions and types are linked to the specification, so you
 can click them to learn more.
-You are encouraged to submit feedback to https://github
-.com/KhronosGroup/Vulkan-Docs[this Khronos repository].
+You are encouraged to submit feedback to https://github.com/KhronosGroup/Vulkan-Docs[this Khronos repository].
 
 As mentioned before, the Vulkan API has a rather verbose API with many
 parameters to give you maximum control over the graphics hardware.

--- a/en/01_Overview.adoc
+++ b/en/01_Overview.adoc
@@ -28,8 +28,8 @@ with the existing APIs somehow. This resulted in less than ideal abstractions
 Aside from these new features, the past decade also saw an influx of mobile
 and embedded devices with powerful graphics hardware. These mobile GPUs have
  different architectures based on their energy and space requirements.
-One such example is https://en.wikipedia.org/wiki/Tiled_rendering[tiled
-rendering], which would benefit from improved performance by offering the
+One such example is https://en.wikipedia.org/wiki/Tiled_rendering[tiled rendering], 
+which would benefit from improved performance by offering the
 programmer more control over this functionality.
 Another limitation originating from the age of these APIs is limited
 multi-threading support, which can result in a bottleneck on the CPU side.

--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -297,7 +297,7 @@ The most important parts you'll need for developing Vulkan applications on
 Linux are the Vulkan loader, validation layers, and a couple of command-line
 utilities to test whether your machine is Vulkan-capable:
 
-Download the VulkanSDK tarball from (https://vulkan.lunarg.com/)[LunarG].
+Download the VulkanSDK tarball from https://vulkan.lunarg.com/[LunarG].
 Place the uncompressed VulkanSDK in a convenient path, and create a symbolic
 link to the latest on like so:
 
@@ -410,9 +410,9 @@ CMake project for Vulkan and write a little bit of code to make sure that
 everything works.
 
 I will assume that you already have some basic experience with CMake, like
-how variables and rules work. If not, you can get up to speed very quickly with (https://cmake.org/cmake/help/book/mastering-cmake/cmake/Help/guide/tutorial/)[this tutorial].
+how variables and rules work. If not, you can get up to speed very quickly with https://cmake.org/cmake/help/book/mastering-cmake/cmake/Help/guide/tutorial/[this tutorial].
 
-You can now use the ink:/attachments/[attachments] directory in this tutorial as a template for your
+You can now use the link:/attachments/[attachments] directory in this tutorial as a template for your
 Vulkan projects. Make a copy, rename it to something like `HelloTriangle`
 and remove all the code in `main.cpp`.
 
@@ -465,7 +465,7 @@ Most of the instructions here are essentially a lot of "plumbing," so we can get
 Also, keep in mind that during the following instructions whenever we mention the folder `vulkansdk` we are referring to the folder where you extracted the Vulkan SDK.
 
 We recommend using CMake everywhere, and Apple is no different. An example
-of how to use CMake for Apple can be found (https://medium.com/practical-coding/migrating-to-cmake-in-c-and-getting-it-working-with-xcode-50b7bb80ae3d)[here]
+of how to use CMake for Apple can be found https://medium.com/practical-coding/migrating-to-cmake-in-c-and-getting-it-working-with-xcode-50b7bb80ae3d[here]
 We also have documentation for using a cmake project in Apple environments
 at the VulkanSamples project.  It targets both iOS and Desktop Apple.
 

--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -97,8 +97,7 @@ find_package(Slang CONFIG HINTS "$ENV{VULKAN_SDK}/lib/cmake").
 In the future, FindVulkan.cmake might migrate to the *-config.cmake standard,
 however at the time of writing it is recommended to grab FindVulkan.cmake
 from VulkanSamples, as the one from Kitware is both deprecated and has bugs
-in the macOS build.  You will find it in the code directory [FindVulkan.
-cmake](!../code/CMake/FindVulkan.cmake)
+in the macOS build. You will find it in the code directory link:/attachments/CMake/FindVulkan.cmake[FindVulkan.cmake].
 
 Using FindVulkan.cmake is a project-specific file, you can take it and make
 changes as necessary to work well in your build environment, and can craft
@@ -112,8 +111,8 @@ To use it, add it to your CMAKE_MODULE_PATH like this:
 ----
 
 This will allow other projects that distribute via Find*.cmake to be placed
-in that same folder. See the accompanying link:/attachments/CMakeLists
-.txt[Cmakelists.txt] for an example of a working project.
+in that same folder. See the accompanying link:/attachments/CMakeLists.txt[CMakeLists.txt]
+for an example of a working project.
 
 Vulkan has support for C{pp} modules which became available with c{pp}20. A
 large advantage of C{pp} modules is they give all the benefits of C{pp} without

--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -72,8 +72,8 @@ your auto-start for your terminal and IDE setup such that those environment
 variables work everywhere.
 
 If you receive an error message, then ensure that your drivers are up to date,
-include the Vulkan runtime and that your graphics card is supported. See the
-[introduction chapter](!en/Introduction) for links to drivers from the major
+include the Vulkan runtime and that your graphics card is supported. See the 
+xref:00_Introduction.adoc[introduction chapter] for links to drivers from the major
 vendors.
 
 === CMake

--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
@@ -291,6 +291,6 @@ in the cleanup() function. This code will never need to change again.
 
 When you run the program now, you should see a window titled `Vulkan` show up
 until the application is terminated by closing the window. Now that we have the
-skeleton for the Vulkan application, let's [create the first Vulkan object](!en/Drawing_a_triangle/Setup/Instance)!
+skeleton for the Vulkan application, let's xref:./01_Instance.adoc[create the first Vulkan object]!
 
 link:/attachments/00_base_code.cpp[C{pp} code]

--- a/en/03_Drawing_a_triangle/00_Setup/01_Instance.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/01_Instance.adoc
@@ -220,6 +220,6 @@ that checks if all the extensions returned by
 list.
 
 Before continuing with the more complex steps after instance creation, it's time
-to evaluate our debugging options by checking out (!en/Drawing_a_triangle/Setup/Validation_layers)[validation layers].
+to evaluate our debugging options by checking out xref:./02_Validation_layers.adoc[validation layers].
 
 link:/attachments/01_instance_creation.cpp[C{pp} code]

--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -162,7 +162,7 @@ extension in the swap chain chapter.
 
 Previous implementations of Vulkan made a distinction between instance and
 device-specific validation layers, but this is
-(https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap40.html#extendingvulkan-layers-devicelayerdeprecation)[no longer the case].
+link:https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/chap40.html#extendingvulkan-layers-devicelayerdeprecation[no longer the case].
 That means that the `enabledLayerCount` and `ppEnabledLayerNames` fields of
 `VkDeviceCreateInfo` are ignored by up-to-date implementations.
 

--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
@@ -469,7 +469,7 @@ your swap chain becomes invalid or unoptimized while your application is
 running, for example, because the window was resized. In that case, the swap chain
 actually needs to be recreated from scratch, and a reference to the old one must
 be specified in this field. This is a complex topic that we'll learn more about
-in [a future chapter](!en/Drawing_a_triangle/Swap_chain_recreation). For now, we'll assume that we'll only ever create
+in xref:03_Drawing_a_triangle/04_Swap_chain_recreation.adoc[a future chapter]. For now, we'll assume that we'll only ever create
 one swap chain.
 
 Now add a class member to store the `VkSwapchainKHR` object:
@@ -494,7 +494,7 @@ Now run the application to ensure that the swap chain is created
 successfully! If at this point you get an access violation error in
 `vkCreateSwapchainKHR` or see a message like `Failed to find
 'vkGetInstanceProcAddress' in layer SteamOverlayVulkanLayer.dll`, then see
-the [FAQ entry](!en/FAQ) about the Steam overlay layer.
+the xref:90_FAQ.adoc[FAQ entry] about the Steam overlay layer.
 
 Try removing the `createInfo.imageExtent = extent;` line with validation layers
 enabled. You'll see that one of the validation layers immediately catches the

--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
@@ -158,7 +158,7 @@ that order with an 8-bit unsigned integer for a total of 32 bits per pixel. The
 the `VK_COLOR_SPACE_SRGB_NONLINEAR_KHR` flag. Note that this flag used to be
 called `VK_COLORSPACE_SRGB_NONLINEAR_KHR` in old versions of the specification.
 
-For the color space we'll use SRGB if it is available, because it [results in more accurate perceived colors](http://stackoverflow.com/questions/12524623/). It is also pretty much the standard color space for images, like the textures we'll use later on.
+For the color space we'll use SRGB if it is available, because it link:http://stackoverflow.com/questions/12524623/[results in more accurate perceived colors]. It is also pretty much the standard color space for images, like the textures we'll use later on.
 Because of that we should also use an SRGB color format, of which one of the most common ones is `VK_FORMAT_B8G8R8A8_SRGB`.
 
 Let's go through the list and see if the preferred combination is available:
@@ -267,7 +267,7 @@ resolution that best matches the window within the `minImageExtent` and
 `maxImageExtent` bounds. But we must specify the resolution in the correct unit.
 
 GLFW uses two units when measuring sizes: pixels and
-[screen coordinates](https://www.glfw.org/docs/latest/intro_guide.html#coordinate_systems).
+link:https://www.glfw.org/docs/latest/intro_guide.html#coordinate_systems[screen coordinates].
 For example, the resolution `{WIDTH, HEIGHT}` that we specified earlier when
 creating the window is measured in screen coordinates. But Vulkan works with
 pixels, so the swap chain extent must be specified in pixels as well.

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/00_Introduction.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/00_Introduction.adoc
@@ -72,7 +72,7 @@ pipeline are known in advance, the driver can optimize for it much better.
 Some of the programmable stages are optional based on what you intend to do. For
 example, the tessellation and geometry stages can be disabled if you are just
 drawing simple geometry. If you are only interested in depth values, then you can
-disable the fragment shader stage, which is useful for [shadow map](https://en.wikipedia.org/wiki/Shadow_mapping)
+disable the fragment shader stage, which is useful for link:https://en.wikipedia.org/wiki/Shadow_mapping[shadow map]
 generation.
 
 In the next chapter, we'll first create the two programmable stages required to


### PR DESCRIPTION
PR #61 broke a few internal and external links. This PR fixes them.

@marty-johnson59, @gpx1000: We should merge this before the docs site is published with the updated tutorial.