### PR TITLE
Fix chapter links

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -207,7 +207,7 @@ graphicsQueue = vk::raii::Queue( device, graphicsIndex, 0 );
 
 With the logical device and queue handles, we can now actually start using the
 graphics card to do things! In the
-link:../01_Presentation/00_Window_surface.adoc[next few chapters], we'll set
+xref:/03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc[next few chapters], we'll set
  up the resources to present results to the window system.
 
 link:/attachments/04_logical_device.cpp[C{pp} code]

--- a/en/03_Drawing_a_triangle/01_Presentation/02_Image_views.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/02_Image_views.adoc
@@ -133,6 +133,6 @@ for (auto image : swapChainImages) {
 
 An image view is sufficient to start using an image as a texture, but it's not quite ready to be used as a render target just yet.
 That requires one more step, known as a framebuffer.
-In the link:../02_Graphics_pipeline_basics/00_Introduction.adoc[next chapters,] we'll have to set up the graphics pipeline.
+In the xref:/03_Drawing_a_triangle/02_Graphics_pipeline_basics/00_Introduction.adoc[next chapters,] we'll have to set up the graphics pipeline.
 
 link:/attachments/07_image_views.cpp[C{pp} code]

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
@@ -88,7 +88,7 @@ The graphics pipeline is required for all common drawing operations.
 
 Now run your program to confirm that all this hard work has resulted in a successful pipeline creation!
 We are already getting quite close to seeing something pop up on the screen.
-In the link:../03_Drawing/00_Framebuffers.adoc[next couple of chapters,]
+In the xref:/03_Drawing_a_triangle/03_Drawing/00_Framebuffers.adoc[next couple of chapters,]
 we'll set up the actual framebuffers from the swap chain images and prepare the drawing commands.
 
 link:/attachments/12_graphics_pipeline_complete.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]


### PR DESCRIPTION
@marty-johnson59 @gpx1000 : Sorry for the noise, but I find a few more links that were broken. And as they were using "link" instead of (the correct) "xref", they didn't show up as errors when building the site before.