### PR TITLE
Add layer and extension checks on instance creation

### DIFF
--- a/attachments/01_instance_creation.cpp
+++ b/attachments/01_instance_creation.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <cstdlib>
@@ -58,11 +59,27 @@ private:
             .pEngineName        = "No Engine",
             .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
             .apiVersion         = vk::ApiVersion14 };
+
+        // Get the required instance extensions from GLFW.
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
+
+        // Check if the required GLFW extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (uint32_t i = 0; i < glfwExtensionCount; ++i)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [glfwExtension = glfwExtensions[i]](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, glfwExtension) == 0; }))
+            {
+                throw std::runtime_error("Required GLFW extension not supported: " + std::string(glfwExtensions[i]));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo = &appInfo,
-            .ppEnabledLayerNames = glfwExtensions};
+            .enabledExtensionCount = glfwExtensionCount,
+            .ppEnabledExtensionNames = glfwExtensions};
         instance = vk::raii::Instance(context, createInfo);
     }
 };

--- a/attachments/02_validation_layers.cpp
+++ b/attachments/02_validation_layers.cpp
@@ -68,26 +68,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+            requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const & requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -120,11 +145,6 @@ private:
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/02_validation_layers.cpp
+++ b/attachments/02_validation_layers.cpp
@@ -133,12 +133,6 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );

--- a/attachments/03_physical_device_selection.cpp
+++ b/attachments/03_physical_device_selection.cpp
@@ -78,26 +78,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -159,23 +184,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/04_logical_device.cpp
+++ b/attachments/04_logical_device.cpp
@@ -82,26 +82,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -192,23 +217,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -85,26 +85,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -242,23 +267,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -93,26 +93,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -295,23 +320,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -94,26 +94,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -308,23 +333,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -95,26 +95,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -313,23 +338,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -96,26 +96,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -325,23 +350,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -98,26 +98,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -354,23 +379,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -99,26 +99,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -365,23 +390,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -104,26 +104,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -462,23 +487,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -113,26 +113,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -505,23 +530,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -117,26 +117,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -521,23 +546,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -143,26 +143,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -556,23 +581,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -167,26 +167,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -583,23 +608,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -171,26 +171,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -632,23 +657,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -180,26 +180,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -658,23 +683,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -196,26 +196,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -712,23 +737,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -201,26 +201,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -737,23 +762,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -208,26 +208,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -841,23 +866,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -212,26 +212,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -875,23 +900,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -214,26 +214,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -952,23 +977,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -227,26 +227,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
             .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
             .pEngineName        = "No Engine",
             .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
             .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -1037,23 +1062,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    bool checkValidationLayerSupport() {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -231,26 +231,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -1082,23 +1107,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    [[nodiscard]] bool checkValidationLayerSupport() const {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -232,26 +232,50 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -1149,23 +1173,12 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
         }
 
         return extensions;
-    }
-
-    [[nodiscard]] bool checkValidationLayerSupport() const {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
     }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -239,26 +239,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                     .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                     .pEngineName        = "No Engine",
                     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                     .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -1177,12 +1202,6 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
@@ -1190,11 +1209,6 @@ private:
 
         return extensions;
     }
-
-    [[nodiscard]] bool checkValidationLayerSupport() const {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
-            }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {
         if (severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eError || severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning) {

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -210,26 +210,51 @@ private:
     }
 
     void createInstance() {
-        if (enableValidationLayers && !checkValidationLayerSupport()) {
-            throw std::runtime_error("validation layers requested, but not available!");
-        }
-
         constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
                 .applicationVersion = VK_MAKE_VERSION( 1, 0, 0 ),
                 .pEngineName        = "No Engine",
                 .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
                 .apiVersion         = vk::ApiVersion14 };
-        auto extensions = getRequiredExtensions();
-        std::vector<char const *> enabledLayers;
+
+        // Get the required layers
+        std::vector<char const*> requiredLayers;
         if (enableValidationLayers) {
-            enabledLayers.assign(validationLayers.begin(), validationLayers.end());
+          requiredLayers.assign(validationLayers.begin(), validationLayers.end());
         }
+
+        // Check if the required layers are supported by the Vulkan implementation.
+        auto layerProperties = context.enumerateInstanceLayerProperties();
+        for (auto const& requiredLayer : requiredLayers)
+        {
+            if (std::ranges::none_of(layerProperties,
+                                     [requiredLayer](auto const& layerProperty)
+                                     { return strcmp(layerProperty.layerName, requiredLayer) == 0; }))
+            {
+                throw std::runtime_error("Required layer not supported: " + std::string(requiredLayer));
+            }
+        }
+
+        // Get the required extensions.
+        auto requiredExtensions = getRequiredExtensions();
+
+        // Check if the required extensions are supported by the Vulkan implementation.
+        auto extensionProperties = context.enumerateInstanceExtensionProperties();
+        for (auto const& requiredExtension : requiredExtensions)
+        {
+            if (std::ranges::none_of(extensionProperties,
+                                     [requiredExtension](auto const& extensionProperty)
+                                     { return strcmp(extensionProperty.extensionName, requiredExtension) == 0; }))
+            {
+                throw std::runtime_error("Required extension not supported: " + std::string(requiredExtension));
+            }
+        }
+
         vk::InstanceCreateInfo createInfo{
             .pApplicationInfo        = &appInfo,
-            .enabledLayerCount       = static_cast<uint32_t>(enabledLayers.size()),
-            .ppEnabledLayerNames     = enabledLayers.data(),
-            .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
-            .ppEnabledExtensionNames = extensions.data() };
+            .enabledLayerCount       = static_cast<uint32_t>(requiredLayers.size()),
+            .ppEnabledLayerNames     = requiredLayers.data(),
+            .enabledExtensionCount   = static_cast<uint32_t>(requiredExtensions.size()),
+            .ppEnabledExtensionNames = requiredExtensions.data() };
         instance = vk::raii::Instance(context, createInfo);
     }
 
@@ -917,12 +942,6 @@ private:
         uint32_t glfwExtensionCount = 0;
         auto glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-        std::vector<vk::ExtensionProperties> props = context.enumerateInstanceExtensionProperties();
-        if (const auto propsIterator = std::ranges::find_if(props, []( vk::ExtensionProperties const & ep ) { return strcmp( ep.extensionName, vk::EXTDebugUtilsExtensionName ) == 0; } ); propsIterator == props.end() )
-        {
-            std::cout << "Something went very wrong, cannot find VK_EXT_debug_utils extension" << std::endl;
-            exit( 1 );
-        }
         std::vector extensions(glfwExtensions, glfwExtensions + glfwExtensionCount);
         if (enableValidationLayers) {
             extensions.push_back(vk::EXTDebugUtilsExtensionName );
@@ -930,11 +949,6 @@ private:
 
         return extensions;
     }
-
-    [[nodiscard]] bool checkValidationLayerSupport() const {
-        return (std::ranges::any_of(context.enumerateInstanceLayerProperties(),
-        []( vk::LayerProperties const & lp ) { return ( strcmp( "VK_LAYER_KHRONOS_validation", lp.layerName ) == 0 ); } ) );
-            }
 
     static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT severity, vk::DebugUtilsMessageTypeFlagsEXT type, const vk::DebugUtilsMessengerCallbackDataEXT* pCallbackData, void*) {
         if (severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eError || severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning) {


### PR DESCRIPTION
Note 1: you should mention the existence of the `install_dependencies` scripts in the readme.md!

Note 2: not all projects are successfully building. `00_base_code`, for example, fails.