### PR TITLE
Add exception handling for vk::SystemError

### DIFF
--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -100,7 +100,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -104,7 +104,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -111,7 +111,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();
@@ -535,14 +546,25 @@ private:
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
 
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR( presentInfoKHR );
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR( presentInfoKHR );
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -135,7 +135,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();
@@ -562,14 +573,25 @@ private:
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
 
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR( presentInfoKHR );
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR( presentInfoKHR );
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -139,7 +139,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();
@@ -592,14 +603,25 @@ private:
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
 
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR( presentInfoKHR );
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR( presentInfoKHR );
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -139,7 +139,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();
@@ -611,14 +622,25 @@ private:
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
 
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR( presentInfoKHR );
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR( presentInfoKHR );
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -147,7 +147,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -164,7 +164,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -169,7 +169,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -176,7 +176,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -180,7 +180,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -931,14 +931,25 @@ private:
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
 
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR(presentInfoKHR);
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR(presentInfoKHR);
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -198,7 +198,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -199,7 +199,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -205,7 +205,18 @@ private:
     void mainLoop() {
         while (!glfwWindowShouldClose(window)) {
             glfwPollEvents();
-            drawFrame();
+            try {
+                drawFrame();
+            } catch (const vk::SystemError& e) {
+                if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                    // Swapchain is out of date, this can happen during window close
+                    // Just ignore and continue to close
+                    std::cout << "Ignoring ErrorOutOfDateKHR during shutdown" << std::endl;
+                } else {
+                    // Rethrow other errors
+                    throw;
+                }
+            }
         }
 
         device.waitIdle();
@@ -1155,16 +1166,27 @@ private:
                             .signalSemaphoreCount = 1, .pSignalSemaphores = &*renderFinishedSemaphore[imageIndex] };
         graphicsQueue.submit(submitInfo, *inFlightFences[currentFrame]);
 
-
-        const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
-                                                .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
-        result = presentQueue.presentKHR(presentInfoKHR);
-        if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
-            framebufferResized = false;
-            recreateSwapChain();
-        } else if (result != vk::Result::eSuccess) {
-            throw std::runtime_error("failed to present swap chain image!");
+        try {
+            const vk::PresentInfoKHR presentInfoKHR{ .waitSemaphoreCount = 1, .pWaitSemaphores = &*renderFinishedSemaphore[imageIndex],
+                                                    .swapchainCount = 1, .pSwapchains = &*swapChain, .pImageIndices = &imageIndex };
+            result = presentQueue.presentKHR(presentInfoKHR);
+            if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR || framebufferResized) {
+                framebufferResized = false;
+                recreateSwapChain();
+            } else if (result != vk::Result::eSuccess) {
+                throw std::runtime_error("failed to present swap chain image!");
+            }
+        } catch (const vk::SystemError& e) {
+            if (e.code().value() == static_cast<int>(vk::Result::eErrorOutOfDateKHR)) {
+                // Swapchain is out of date, this can happen during window close
+                // Just ignore and continue to close
+                std::cout << "Ignoring ErrorOutOfDateKHR during presentation" << std::endl;
+            } else {
+                // Rethrow other errors
+                throw;
+            }
         }
+
         semaphoreIndex = (semaphoreIndex + 1) % presentCompleteSemaphore.size();
         currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
     }


### PR DESCRIPTION
This is specific to the issue #73 

- Catch `vk::SystemError` in `mainLoop` and presentation logic to handle `vk::Result::eErrorOutOfDateKHR` gracefully.
- Log and ignore swapchain-related errors during shutdown or presentation to prevent crashes while rethrowing unexpected exceptions.
- Updated multiple attachments for consistent error handling.

We likely will need to add better error detection everywhere; but in the spirit of just handling it when we get an out of date.  It should be properly handled already in the draw function; but this makes it so we don't just throw an exception.  I guess a better solution might be to handle the `vk::Result::eErrorOutOfDateKHR` by sending it to resize multiple times rather than the once.  However, I think this is the right solution for now for this.