### PR TITLE
Update shader links and improve Slang shader references across all ch…

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
@@ -281,10 +281,10 @@ Create a `compile.bat` file with the following contents:
 
 [,bash]
 ----
-C:/VulkanSDK/x.x.x.x/bin/slang.exe shader.slang -target spirv -profile spirv_1_4 -emit-spirv-directly -fvk-use-entrypoint-name -entry vertMain -entry fragMain -o slang.spv
+C:/VulkanSDK/x.x.x.x/bin/slangc.exe shader.slang -target spirv -profile spirv_1_4 -emit-spirv-directly -fvk-use-entrypoint-name -entry vertMain -entry fragMain -o slang.spv
 ----
 
-Replace the path to `slang.exe` with the path to where you installed
+Replace the path to `slangc.exe` with the path to where you installed
 the Vulkan SDK. Double-click the file to run it.
 
 *Linux*
@@ -530,4 +530,7 @@ vk::PipelineShaderStageCreateInfo shaderStages[] = {vertShaderStageInfo, fragSha
 That's all there is describing the programmable stages of the pipeline.
 In the xref:./02_Fixed_functions.adoc[next chapter,] we'll look at the fixed-function stages.
 
-link:/attachments/09_shader_modules.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/09_shader_modules.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
@@ -341,4 +341,7 @@ This reduces the chance of running into unexpected behavior because the default 
 
 There is, however, one more object to create before we can finally create the graphics pipeline, and that is a xref:./03_Render_passes.adoc[render pass].
 
-link:/attachments/10_fixed_functions.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/10_fixed_functions.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/03_Render_passes.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/03_Render_passes.adoc
@@ -39,4 +39,7 @@ The advantage of dynamic rendering is that it simplifies the rendering process b
 
 In the xref:./04_Conclusion.adoc[next chapter], we'll put everything together to finally create the graphics pipeline object!
 
-link:/attachments/12_graphics_pipeline_complete.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/12_graphics_pipeline_complete.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
@@ -91,4 +91,7 @@ We are already getting quite close to seeing something pop up on the screen.
 In the xref:/03_Drawing_a_triangle/03_Drawing/00_Framebuffers.adoc[next couple of chapters,]
 we'll set up the actual framebuffers from the swap chain images and prepare the drawing commands.
 
-link:/attachments/12_graphics_pipeline_complete.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/12_graphics_pipeline_complete.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/03_Drawing/00_Framebuffers.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/00_Framebuffers.adoc
@@ -82,4 +82,7 @@ With this approach, we don't need to create framebuffers or render passes, which
 
 In the xref:./01_Command_buffers.adoc[next chapter,] we'll create command buffers and write the first actual drawing commands using dynamic rendering.
 
-link:/attachments/14_command_buffers.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/14_command_buffers.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.adoc
@@ -334,4 +334,7 @@ commandBuffer.end();
 
 In the xref:./02_Rendering_and_presentation.adoc[next chapter] we'll write the code for the main loop, which will acquire an image from the swap chain, record and execute a command buffer, then return the finished image to the swap chain.
 
-link:/attachments/14_command_buffers.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/14_command_buffers.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/03_Drawing/02_Rendering_and_presentation.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/02_Rendering_and_presentation.adoc
@@ -441,4 +441,7 @@ barriers and further refine our understanding of synchronization in Vulkan.
 
 The xref:./03_Frames_in_flight.adoc[next chapter] will expand the render loop to handle multiple frames in flight.
 
-link:/attachments/15_hello_triangle.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/15_hello_triangle.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/03_Drawing/03_Frames_in_flight.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/03_Frames_in_flight.adoc
@@ -146,4 +146,7 @@ To learn more about synchronization through examples, have a look at https://git
 In the xref:../03_Drawing_a_triangle/04_Swap_chain_recreation.adoc[next
 chapter] we'll deal with one more small thing required for a well-behaved Vulkan program.
 
-link:/attachments/16_frames_in_flight.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/16_frames_in_flight.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/03_Drawing_a_triangle/04_Swap_chain_recreation.adoc
+++ b/en/03_Drawing_a_triangle/04_Swap_chain_recreation.adoc
@@ -246,4 +246,7 @@ The initial call to `glfwGetFramebufferSize` handles the case where the size is 
 Congratulations, you've now finished your very first well-behaved Vulkan program!
 In the xref:04_Vertex_buffers/00_Vertex_input_description.adoc[next chapter] we're going to get rid of the hardcoded vertices in the vertex shader and actually use a vertex buffer.
 
-link:/attachments/17_swap_chain_recreation.cpp[C{pp} code] / link:/attachments/09_shader_base.vert[Vertex shader] / link:/attachments/09_shader_base.frag[Fragment shader]
+link:/attachments/17_swap_chain_recreation.cpp[C{pp} code] /
+link:/attachments/09_shader_base.slang[Slang shader] /
+link:/attachments/09_shader_base.vert[GLSL Vertex shader] /
+link:/attachments/09_shader_base.frag[GLSL Fragment shader]

--- a/en/04_Vertex_buffers/00_Vertex_input_description.adoc
+++ b/en/04_Vertex_buffers/00_Vertex_input_description.adoc
@@ -181,4 +181,7 @@ The pipeline is now ready to accept vertex data in the format of the `vertices` 
 If you run the program now with validation layers enabled, you'll see that it complains that there is no vertex buffer bound to the binding.
 The xref:./01_Vertex_buffer_creation.adoc[next step] is to create a vertex buffer and move the vertex data to it so the GPU is able to access it.
 
-link:/attachments/18_vertex_input.cpp[C{pp} code] / link:/attachments/18_shader_vertexbuffer.vert[Vertex shader] / link:/attachments/18_shader_vertexbuffer.frag[Fragment shader]
+link:/attachments/18_vertex_input.cpp[C{pp} code] /
+link:/attachments/18_shader_vertexbuffer.slang[slang shader] /
+link:/attachments/18_shader_vertexbuffer.vert[GLSL Vertex shader] /
+link:/attachments/18_shader_vertexbuffer.frag[GLSL Fragment shader]

--- a/en/04_Vertex_buffers/01_Vertex_buffer_creation.adoc
+++ b/en/04_Vertex_buffers/01_Vertex_buffer_creation.adoc
@@ -263,4 +263,7 @@ image::/images/triangle_white.png[]
 
 In the xref:./02_Staging_buffer.adoc[next chapter,] we'll look at a different way to copy vertex data to a vertex buffer that results in better performance, but takes some more work.
 
-link:/attachments/19_vertex_buffer.cpp[C{pp} code] / link:/attachments/18_shader_vertexbuffer.vert[Vertex shader] / link:/attachments/18_shader_vertexbuffer.frag[Fragment shader]
+link:/attachments/19_vertex_buffer.cpp[C{pp} code] /
+link:/attachments/18_shader_vertexbuffer.slang[slang shader] /
+link:/attachments/18_shader_vertexbuffer.vert[GLSL Vertex shader] /
+link:/attachments/18_shader_vertexbuffer.frag[GLSL Fragment shader]

--- a/en/04_Vertex_buffers/02_Staging_buffer.adoc
+++ b/en/04_Vertex_buffers/02_Staging_buffer.adoc
@@ -205,4 +205,7 @@ However, for this tutorial, it's okay to use a separate allocation for every res
 
 In the xref:./03_Index_buffer.adoc[next chapter,] we'll learn about index buffers for vertex reuse.
 
-link:/attachments/20_staging_buffer.cpp[C{pp} code] / link:/attachments/18_shader_vertexbuffer.vert[Vertex shader] / link:/attachments/18_shader_vertexbuffer.frag[Fragment shader]
+link:/attachments/20_staging_buffer.cpp[C{pp} code] /
+link:/attachments/18_shader_vertexbuffer.slang[slang shader] /
+link:/attachments/18_shader_vertexbuffer.vert[GLSL Vertex shader] /
+link:/attachments/18_shader_vertexbuffer.frag[GLSL Fragment shader]

--- a/en/04_Vertex_buffers/03_Index_buffer.adoc
+++ b/en/04_Vertex_buffers/03_Index_buffer.adoc
@@ -140,4 +140,7 @@ This is known as _aliasing_ and some Vulkan functions have explicit flags to spe
 
 The xref:05_Uniform_buffers/00_Descriptor_set_layout_and_buffer.adoc[next chapter] we'll learn how to pass frequently changing parameters to the GPU.
 
-link:/attachments/21_index_buffer.cpp[C{pp} code] / link:/attachments/18_shader_vertexbuffer.vert[Vertex shader] / link:/attachments/18_shader_vertexbuffer.frag[Fragment shader]
+link:/attachments/21_index_buffer.cpp[C{pp} code] /
+link:/attachments/18_shader_vertexbuffer.slang[slang shader] /
+link:/attachments/18_shader_vertexbuffer.vert[GLSL Vertex shader] /
+link:/attachments/18_shader_vertexbuffer.frag[GLSL Fragment shader]

--- a/en/05_Uniform_buffers/00_Descriptor_set_layout_and_buffer.adoc
+++ b/en/05_Uniform_buffers/00_Descriptor_set_layout_and_buffer.adoc
@@ -367,4 +367,7 @@ We may look at these in a future chapter.
 
 In the xref:./01_Descriptor_pool_and_sets.adoc[next chapter] we'll look at descriptor sets, which will actually bind the ``VkBuffer``s to the uniform buffer descriptors so that the shader can access this transformation data.
 
-link:/attachments/22_descriptor_set_layout.cpp[C{pp} code] / link:/attachments/22_shader_ubo.vert[Vertex shader] / link:/attachments/22_shader_ubo.frag[Fragment shader]
+link:/attachments/22_descriptor_set_layout.cpp[C{pp} code] /
+link:/attachments/22_shader_ubo.slang[slang shader] /
+link:/attachments/22_shader_ubo.vert[GLSL Vertex shader] /
+link:/attachments/22_shader_ubo.frag[GLSL Fragment shader]

--- a/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.adoc
+++ b/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.adoc
@@ -355,4 +355,7 @@ In that case, you avoid rebinding most of the descriptors across draw calls whic
 
 In the xref:06_Texture_mapping/00_Images.adoc[next chapters] we'll build upon what we just learned and add textures to our scene.
 
-link:/attachments/23_descriptor_sets.cpp[C{pp} code] / link:/attachments/22_shader_ubo.vert[Vertex shader] / link:/attachments/22_shader_ubo.frag[Fragment shader]
+link:/attachments/23_descriptor_sets.cpp[C{pp} code]  /
+link:/attachments/22_shader_ubo.slang[slang shader] /
+link:/attachments/22_shader_ubo.vert[GLSL Vertex shader] /
+link:/attachments/22_shader_ubo.frag[GLSL Fragment shader]

--- a/en/06_Texture_mapping/00_Images.adoc
+++ b/en/06_Texture_mapping/00_Images.adoc
@@ -500,4 +500,7 @@ It's best to do this after the texture mapping works to check if the texture res
 The image now contains the texture, but we still need a way to access it from the graphics pipeline.
 We'll work on that in the xref:./01_Image_view_and_sampler.adoc[next chapter].
 
-link:/attachments/24_texture_image.cpp[C{pp} code] / link:/attachments/22_shader_ubo.slang[Slang shader]
+link:/attachments/24_texture_image.cpp[C{pp} code] /
+link:/attachments/22_shader_ubo.slang[slang shader] /
+link:/attachments/22_shader_ubo.vert[GLSL Vertex shader] /
+link:/attachments/22_shader_ubo.frag[GLSL Frag shader]

--- a/en/06_Texture_mapping/01_Image_view_and_sampler.adoc
+++ b/en/06_Texture_mapping/01_Image_view_and_sampler.adoc
@@ -296,4 +296,7 @@ samplerInfo.maxAnisotropy = 1.0f;
 
 In the xref:./02_Combined_image_sampler.adoc[next chapter] we will expose the image and sampler objects to the shaders to draw the texture onto the square.
 
-link:/attachments/25_sampler.cpp[C{pp} code] / link:/attachments/22_shader_ubo.slang[Slang shader]
+link:/attachments/25_sampler.cpp[C{pp} code] /
+link:/attachments/22_shader_ubo.slang[slang shader] /
+link:/attachments/22_shader_ubo.vert[GLSL Vertex shader] /
+link:/attachments/22_shader_ubo.frag[GLSL Fragment shader]

--- a/en/06_Texture_mapping/02_Combined_image_sampler.adoc
+++ b/en/06_Texture_mapping/02_Combined_image_sampler.adoc
@@ -238,4 +238,6 @@ You can use these images as inputs to implement cool effects like post-processin
 In the xref:07_Depth_buffering.adoc[next chapter] we'll learn how to add depth buffering for properly sorting objects.
 
 link:/attachments/26_texture_mapping.cpp[C{pp} code] /
-link:/attachments/26_shader_textures.slang[Slang shader]
+link:/attachments/26_shader_textures.slang[slang shader] /
+link:/attachments/26_shader_textures.vert[GLSL Vertex shader] /
+link:/attachments/26_shader_textures.frag[GLSL Fragment shader]

--- a/en/07_Depth_buffering.adoc
+++ b/en/07_Depth_buffering.adoc
@@ -501,4 +501,7 @@ void recreateSwapChain() {
 Congratulations, your application is now finally ready to render arbitrary 3D geometry and have it look right.
 We're going to try this out in the xref:08_Loading_models.adoc[next chapter] by drawing a textured model!
 
-link:/attachments/27_depth_buffering.cpp[C{pp} code] / link:/attachments/27_shader_depth.slang[Slang shader]
+link:/attachments/27_depth_buffering.cpp[C{pp} code] /
+link:/attachments/27_shader_depth.slang[slang shader] /
+link:/attachments/27_shader_depth.vert[GLSL Vertex shader] /
+link:/attachments/27_shader_depth.frag[GLSL Fragment shader]

--- a/en/08_Loading_models.adoc
+++ b/en/08_Loading_models.adoc
@@ -293,4 +293,7 @@ This definitely saves us a lot of GPU memory.
 
 In the xref:09_Generating_Mipmaps.adoc[next chapter,] we'll learn about a technique to improve texture rendering.
 
-link:/attachments/28_model_loading.cpp[C{pp} code] / link:/attachments/27_shader_depth.slang[Slang shader]
+link:/attachments/28_model_loading.cpp[C{pp} code] /
+link:/attachments/27_shader_depth.slang[slang shader] /
+link:/attachments/27_shader_depth.vert[GLSL Vertex shader] /
+link:/attachments/27_shader_depth.frag[GLSL Fragment shader]

--- a/en/09_Generating_Mipmaps.adoc
+++ b/en/09_Generating_Mipmaps.adoc
@@ -440,4 +440,6 @@ This is how higher mip levels will be used when objects are further away from th
 The xref:10_Multisampling.adoc[next chapter] will walk us through multisampling to produce a smoother image.
 
 link:/attachments/29_mipmapping.cpp[C{pp} code] /
-link:/attachments/27_shader_depth.slang[Slang shader]
+link:/attachments/27_shader_depth.slang[slang shader] /
+link:/attachments/27_shader_depth.vert[GLSL Vertex shader] /
+link:/attachments/27_shader_depth.frag[GLSL Fragment shader]

--- a/en/10_Multisampling.adoc
+++ b/en/10_Multisampling.adoc
@@ -326,4 +326,6 @@ The current program can be extended in many ways, like adding Blinn-Phong lighti
 You should be able to learn how these effects work from tutorials for other APIs, because despite Vulkan's explicitness, many concepts still work the same.
 
 link:/attachments/30_multisampling.cpp[C{pp} code] /
-link:/attachments/27_shader_depth.slang[SLang shader]
+link:/attachments/27_shader_depth.slang[slang shader] /
+link:/attachments/27_shader_depth.vert[GLSL Vertex shader] /
+link:/attachments/27_shader_depth.frag[GLSL Fragment shader]

--- a/en/11_Compute_Shader.adoc
+++ b/en/11_Compute_Shader.adoc
@@ -838,4 +838,7 @@ So now that you know how to use compute shaders, you may want to take a look at 
 You can find some advanced compute samples in the https://github.com/KhronosGroup/Vulkan-Samples/tree/master/samples/api[official Khronos Vulkan Samples repository].
 
 link:/attachments/31_compute_shader.cpp[C{pp} code] /
-link:/attachments/31_shader_compute.slang[Slang shader]
+link:/attachments/31_shader_compute.slang[slang shader] /
+link:/attachments/31_shader_compute.vert[GLSL Vertex shader] /
+link:/attachments/31_shader_compute.frag[GLSL Fragment shader] /
+link:/attachments/31_shader_compute.comp[GLSL Compute shader]


### PR DESCRIPTION
…apters

- Replace "Slang shader" references for consistent naming convention (`slang shader`).
- Add GLSL shader links (Vertex, Fragment, and Compute where applicable) alongside `C++` code in all relevant chapters.
- Correct usage of `slangc.exe` in shader compilation instructions.

addresses issue #88 