### PR TITLE
cleanupSwapChain in 17_swap_chain_recreation.cpp was not destroying the previous swapchain

### DIFF
--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -124,6 +124,7 @@ private:
 
     void cleanupSwapChain() {
         swapChainImageViews.clear();
+        swapChain = nullptr;
     }
 
     void cleanup() {


### PR DESCRIPTION
As the title says, the source code was missing a simple `swapChain = nullptr;` (that is actually present in the tutorial).
Without this fix the swapChain recreation crashes (`Device::createSwapchainKHR: ErrorSurfaceLostKHR`).