### PR TITLE
Revert back to a working version of Findtinygltf.cmake

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,6 @@
 name: CMake CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       force_android_build:
@@ -12,7 +8,10 @@ on:
         required: false
         type: boolean
         default: false
-
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches: [ main ]
 jobs:
 
   check-android-changes:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -410,8 +410,8 @@ jobs:
         working-directory: ${{github.workspace}}/attachments
         if: runner.os != 'Windows'
         run: |
-          export CC="ccache clang"
-          export CXX="ccache clang++"
+          export CC="clang"
+          export CXX="clang++"
 
           cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_SCAN_FOR_MODULES=ON \

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      force_android_build:
+        description: 'Force Android build to run regardless of file changes'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
 
@@ -436,7 +443,7 @@ jobs:
 
     # We need to run a preliminary job to check for changes
     needs: check-android-changes
-    if: needs.check-android-changes.outputs.should_build == 'true'
+    if: needs.check-android-changes.outputs.should_build == 'true' || github.event.inputs.force_android_build == 'true'
 
     steps:
       - uses: actions/checkout@v3

--- a/attachments/CMake/Findtinygltf.cmake
+++ b/attachments/CMake/Findtinygltf.cmake
@@ -1,11 +1,11 @@
-# FindTinyGLTF.cmake
+# Findtinygltf.cmake
 #
-# Finds the TinyGLTF library
+# Finds the tinygltf library
 #
 # This will define the following variables
 #
-#    TinyGLTF_FOUND
-#    TinyGLTF_INCLUDE_DIRS
+#    tinygltf_FOUND
+#    tinygltf_INCLUDE_DIRS
 #
 # and the following imported targets
 #
@@ -25,89 +25,101 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-# Try to find TinyGLTF using standard find_package
-find_path(TinyGLTF_INCLUDE_DIR
+# Try to find tinygltf using standard find_package
+find_path(tinygltf_INCLUDE_DIR
   NAMES tiny_gltf.h
-  PATH_SUFFIXES include tinygltf
+  PATHS
+    ${PC_tinygltf_INCLUDE_DIRS}
+    /usr/include
+    /usr/local/include
+    $ENV{VULKAN_SDK}/include
+    ${ANDROID_NDK}/sources/third_party
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../third_party
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../attachments/external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../attachments/third_party
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../attachments/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../../external
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../../third_party
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../../include
+  PATH_SUFFIXES tinygltf include
 )
+
+# If not found, use FetchContent to download and build
+if(NOT tinygltf_INCLUDE_DIR)
+  # If not found, use FetchContent to download and build
+  include(FetchContent)
+
+  message(STATUS "tinygltf not found, fetching from GitHub...")
+  FetchContent_Declare(
+    tinygltf
+    GIT_REPOSITORY https://github.com/syoyo/tinygltf.git
+    GIT_TAG v2.8.18  # Use a specific tag for stability
+  )
+
+  # Set policy to suppress the deprecation warning
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
+
+  # Populate the content but don't configure it yet
+  FetchContent_GetProperties(tinygltf)
+  if(NOT tinygltf_POPULATED)
+    FetchContent_Populate(tinygltf)
+
+    # Update the minimum required CMake version to avoid deprecation warning
+    file(READ "${tinygltf_SOURCE_DIR}/CMakeLists.txt" TINYGLTF_CMAKE_CONTENT)
+    string(REPLACE "cmake_minimum_required(VERSION 3.6)"
+                   "cmake_minimum_required(VERSION 3.10)"
+                   TINYGLTF_CMAKE_CONTENT "${TINYGLTF_CMAKE_CONTENT}")
+    file(WRITE "${tinygltf_SOURCE_DIR}/CMakeLists.txt" "${TINYGLTF_CMAKE_CONTENT}")
+
+    # Create a symbolic link to make nlohmann/json.hpp available
+    if(EXISTS "${tinygltf_SOURCE_DIR}/json.hpp")
+      file(MAKE_DIRECTORY "${tinygltf_SOURCE_DIR}/nlohmann")
+      file(CREATE_LINK "${tinygltf_SOURCE_DIR}/json.hpp" "${tinygltf_SOURCE_DIR}/nlohmann/json.hpp" SYMBOLIC)
+    endif()
+
+    # Set tinygltf to header-only mode
+    set(TINYGLTF_HEADER_ONLY ON CACHE BOOL "Use header only version" FORCE)
+    set(TINYGLTF_INSTALL OFF CACHE BOOL "Do not install tinygltf" FORCE)
+
+    # Add the subdirectory after modifying the CMakeLists.txt
+    add_subdirectory(${tinygltf_SOURCE_DIR} ${tinygltf_BINARY_DIR})
+  else()
+    # If already populated, just make it available
+    FetchContent_MakeAvailable(tinygltf)
+  endif()
+
+  # Get the include directory from the target
+  get_target_property(tinygltf_INCLUDE_DIR tinygltf INTERFACE_INCLUDE_DIRECTORIES)
+  if(NOT tinygltf_INCLUDE_DIR)
+    # If we can't get the include directory from the target, use the source directory
+    FetchContent_GetProperties(tinygltf SOURCE_DIR tinygltf_SOURCE_DIR)
+    set(tinygltf_INCLUDE_DIR ${tinygltf_SOURCE_DIR})
+  endif()
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(tinygltf
-  REQUIRED_VARS TinyGLTF_INCLUDE_DIR
-  FAIL_MESSAGE ""  # Suppress the error message to allow our fallback
+  REQUIRED_VARS tinygltf_INCLUDE_DIR
 )
 
-if(TinyGLTF_FOUND)
-  set(TinyGLTF_INCLUDE_DIRS ${TinyGLTF_INCLUDE_DIR})
+if(tinygltf_FOUND)
+  set(tinygltf_INCLUDE_DIRS ${tinygltf_INCLUDE_DIR})
 
   if(NOT TARGET tinygltf::tinygltf)
     add_library(tinygltf::tinygltf INTERFACE IMPORTED)
     set_target_properties(tinygltf::tinygltf PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${TinyGLTF_INCLUDE_DIRS}"
+      INTERFACE_INCLUDE_DIRECTORIES "${tinygltf_INCLUDE_DIRS}"
       INTERFACE_COMPILE_DEFINITIONS "TINYGLTF_IMPLEMENTATION;TINYGLTF_NO_EXTERNAL_IMAGE;TINYGLTF_NO_STB_IMAGE;TINYGLTF_NO_STB_IMAGE_WRITE"
     )
     if(TARGET nlohmann_json::nlohmann_json)
       target_link_libraries(tinygltf::tinygltf INTERFACE nlohmann_json::nlohmann_json)
     endif()
   endif()
-else()
-  # If not found, create a custom tinygltf implementation
-  message(STATUS "TinyGLTF not found, creating a custom implementation...")
-
-  # Create a directory for our custom tinygltf implementation
-  set(TINYGLTF_DIR "${CMAKE_CURRENT_BINARY_DIR}/tinygltf")
-  file(REMOVE_RECURSE "${TINYGLTF_DIR}")
-  file(MAKE_DIRECTORY "${TINYGLTF_DIR}")
-
-  # Download the necessary files directly
-  file(DOWNLOAD
-    "https://raw.githubusercontent.com/syoyo/tinygltf/v2.8.18/tiny_gltf.h"
-    "${TINYGLTF_DIR}/tiny_gltf.h"
-    SHOW_PROGRESS
-  )
-
-  file(DOWNLOAD
-    "https://raw.githubusercontent.com/syoyo/tinygltf/v2.8.18/json.hpp"
-    "${TINYGLTF_DIR}/json.hpp"
-    SHOW_PROGRESS
-  )
-
-  file(DOWNLOAD
-    "https://raw.githubusercontent.com/syoyo/tinygltf/v2.8.18/stb_image.h"
-    "${TINYGLTF_DIR}/stb_image.h"
-    SHOW_PROGRESS
-  )
-
-  file(DOWNLOAD
-    "https://raw.githubusercontent.com/syoyo/tinygltf/v2.8.18/stb_image_write.h"
-    "${TINYGLTF_DIR}/stb_image_write.h"
-    SHOW_PROGRESS
-  )
-
-  # Create a symbolic link to make nlohmann/json.hpp available
-  file(MAKE_DIRECTORY "${TINYGLTF_DIR}/nlohmann")
-  file(CREATE_LINK "${TINYGLTF_DIR}/json.hpp" "${TINYGLTF_DIR}/nlohmann/json.hpp" SYMBOLIC)
-
-  # Create a simple CMakeLists.txt file
-  file(WRITE "${TINYGLTF_DIR}/CMakeLists.txt" "
-cmake_minimum_required(VERSION 3.10...3.29)
-project(tinygltf)
-
-if(NOT TARGET tinygltf)
-  add_library(tinygltf INTERFACE)
-  target_include_directories(tinygltf INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_compile_definitions(tinygltf INTERFACE
-    TINYGLTF_IMPLEMENTATION
-    TINYGLTF_NO_EXTERNAL_IMAGE
-    TINYGLTF_NO_STB_IMAGE
-    TINYGLTF_NO_STB_IMAGE_WRITE
-  )
-endif()
-")
-
-  # Add the subdirectory
-  add_subdirectory(${TINYGLTF_DIR} ${CMAKE_CURRENT_BINARY_DIR}/tinygltf-build)
-
+elseif(TARGET tinygltf)
+  # If find_package_handle_standard_args failed but we have a tinygltf target from FetchContent
   # Create an alias for the tinygltf target
   if(NOT TARGET tinygltf::tinygltf)
     add_library(tinygltf_wrapper INTERFACE)
@@ -124,5 +136,27 @@ endif()
     add_library(tinygltf::tinygltf ALIAS tinygltf_wrapper)
   endif()
 
-  set(TinyGLTF_FOUND TRUE)
+  # Set variables to indicate that tinygltf was found
+  set(tinygltf_FOUND TRUE)
+  set(TINYGLTF_FOUND TRUE)
+
+  # Set include directories
+  get_target_property(tinygltf_INCLUDE_DIR tinygltf INTERFACE_INCLUDE_DIRECTORIES)
+  if(tinygltf_INCLUDE_DIR)
+    set(tinygltf_INCLUDE_DIRS ${tinygltf_INCLUDE_DIR})
+  else()
+    # If we can't get the include directory from the target, use the source directory
+    FetchContent_GetProperties(tinygltf SOURCE_DIR tinygltf_SOURCE_DIR)
+    set(tinygltf_INCLUDE_DIR ${tinygltf_SOURCE_DIR})
+    set(tinygltf_INCLUDE_DIRS ${tinygltf_INCLUDE_DIR})
+
+    # Explicitly set the include directory on the target
+    if(TARGET tinygltf)
+      set_target_properties(tinygltf PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${tinygltf_INCLUDE_DIR}"
+      )
+    endif()
 endif()
+endif()
+
+mark_as_advanced(tinygltf_INCLUDE_DIR)

--- a/scripts/install_dependencies_linux.sh
+++ b/scripts/install_dependencies_linux.sh
@@ -45,6 +45,9 @@ case $PACKAGE_MANAGER in
 
         echo "Installing X Window System dependencies..."
         sudo apt-get install -y libxxf86vm-dev libxi-dev
+
+        echo "Installing clang compiler..."
+        sudo apt-get install -y clang
         ;;
     dnf)
         echo "Detected Fedora/RHEL-based system"
@@ -68,6 +71,9 @@ case $PACKAGE_MANAGER in
 
         echo "Installing X Window System dependencies..."
         sudo dnf install -y libXxf86vm-devel libXi-devel
+
+        echo "Installing clang compiler..."
+        sudo dnf install -y clang
         ;;
     pacman)
         echo "Detected Arch-based system"
@@ -88,6 +94,9 @@ case $PACKAGE_MANAGER in
 
         echo "Installing nlohmann-json..."
         sudo pacman -S --needed nlohmann-json || echo "nlohmann-json not found in pacman, will need to be installed manually or via CMake FetchContent"
+
+        echo "Installing clang compiler..."
+        sudo pacman -S --needed clang
         ;;
     *)
         echo "Unsupported package manager. Please install the following packages manually:"
@@ -101,6 +110,7 @@ case $PACKAGE_MANAGER in
         echo "- libtinygltf-dev or equivalent"
         echo "- nlohmann-json3-dev or equivalent"
         echo "- libxxf86vm-dev and libxi-dev or equivalent"
+        echo "- clang compiler"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Add `force_android_build` input and improve `tinygltf` handling in CMake

- Introduce `force_android_build` in the workflow to allow manual triggering of Android builds via `workflow_dispatch`.
- Refactor `TinyGLTF` to `tinygltf` in CMake for consistent naming.
- Enhance fallback behavior to fetch and configure `tinygltf` when not found, ensuring stability.