### PR TITLE
Fix ttarget typo 

### DIFF
--- a/en/02_Development_environment.adoc
+++ b/en/02_Development_environment.adoc
@@ -129,7 +129,7 @@ find_package (Vulkan REQUIRED)
 add_library(VulkanCppModule)
 add_library(Vulkan::cppm ALIAS VulkanCppModule)
 
-ttarget_compile_definitions(VulkanCppModule PUBLIC
+target_compile_definitions(VulkanCppModule PUBLIC
         VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1
         VULKAN_HPP_NO_STRUCT_CONSTRUCTORS=1
 )


### PR DESCRIPTION
This pull request fixes a typo in en/02_Development_environment.adoc
```diff
- ttarget_compile_definitions 
+ target_compile_definitions
```