### PR TITLE
Remove mention of Intel's GPA

### DIFF
--- a/en/12_Ecosystem_Utilities_and_Compatibility.adoc
+++ b/en/12_Ecosystem_Utilities_and_Compatibility.adoc
@@ -198,7 +198,6 @@ Besides GPUInfo.org, several other tools can help you develop and debug Vulkan a
 * *Vendor-specific Tools*:
 ** NVIDIA Nsight Graphics
 ** AMD Radeon GPU Profiler
-** Intel Graphics Performance Analyzers
 
 == Supporting Older GPUs
 


### PR DESCRIPTION
This PR removes the mention of Intel's Graphics Performance Analyzer. It has recently been discontinued without a replacement.