### PR TITLE
Fixed CMake argument omission causing build failure in Shader modules chapter

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
@@ -326,7 +326,7 @@ CMake function:
 [,cmake]
 ----
 function (add_slang_shader_target TARGET)
-  cmake_parse_arguments ("SHADER" "" "SOURCES" "" ${ARGN})
+  cmake_parse_arguments ("SHADER" "" "" "SOURCES" ${ARGN})
   set (SHADERS_DIR ${CMAKE_CURRENT_LIST_DIR}/shaders)
   set (ENTRY_POINTS -entry vertMain -entry fragMain)
   add_custom_command (

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
@@ -326,7 +326,7 @@ CMake function:
 [,cmake]
 ----
 function (add_slang_shader_target TARGET)
-  cmake_parse_arguments ("SHADER" "" "SOURCES" ${ARGN})
+  cmake_parse_arguments ("SHADER" "" "SOURCES" "" ${ARGN})
   set (SHADERS_DIR ${CMAKE_CURRENT_LIST_DIR}/shaders)
   set (ENTRY_POINTS -entry vertMain -entry fragMain)
   add_custom_command (


### PR DESCRIPTION
The CMake documentation defines the version of `cmake_parse_arguments()` used in the `add_slang_shader_target()` function provided in this chapter with the following signature:
```cmake
cmake_parse_arguments(<prefix> <options> <one_value_keywords>
                      <multi_value_keywords> <args>...)
```
The current usage of `cmake_parse_arguments()` in this chapter produces a multiple definition warning and causes build failures due to `${ARGN}` being interpreted as the `<multi_value_keywords>` parameter.

The proposed solution is to add an additional empty set of quotation marks before the "SOURCES" argument to properly pass the arguments to the `${SHADER_SOURCES}` variable.

This categorizes `${SHADER_SOURCES}` as a multi value keyword. I do not know if `${SHADER_SOURCES}` was intended to be a multi or single value keyword, but I opted to select multi value keyword to be consistent with the plurality used throughout the chapter.

This was tested using CMake version 3.29