### PR TITLE
target_add_dependencies not exist in cmake fix it

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
@@ -350,7 +350,7 @@ Then you can add the Slang build step to your target like this:
 [,cmake]
 ----
 add_slang_shader_target( foo SOURCES ${SHADER_SLANG_SOURCES})
-target_add_dependencies(bar PUBLIC foo)
+add_dependencies(bar foo)
 ----
 
 == Loading a shader


### PR DESCRIPTION
target_add_dependencies not exist in cmake fix it with add_dependencies see: https://cmake.org/cmake/help/latest/command/add_dependencies.html