### PR TITLE
Remove explicit CMake version requirement

### DIFF
--- a/attachments/android/app/build.gradle
+++ b/attachments/android/app/build.gradle
@@ -38,6 +38,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
+            version "4.0.2+"
         }
     }
 

--- a/attachments/android/app/build.gradle
+++ b/attachments/android/app/build.gradle
@@ -38,7 +38,6 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "4.0.2"
         }
     }
 


### PR DESCRIPTION
This PR removes the explicit CMake version requirement for Android builds. It was pinned at 4.02, so everyone with a different version would see an error that CMake 4.0.2 could not be found. Even if you have a newer version installed.

Having that explicit requirement pinned to a single version is not necessary and as far as I can tell is safe to remove.

This PR makes it a min. requirement instead.