### PR TITLE
Fix non-working depth buffer for chapters 35 and 36

### DIFF
--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -1197,7 +1197,7 @@ private:
             .newLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-            .image = depthImage,
+            .image = *depthImage,
             .subresourceRange = {
                 .aspectMask = vk::ImageAspectFlagBits::eDepth,
                 .baseMipLevel = 0,

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -1286,7 +1286,7 @@ private:
             .newLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal,
             .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
             .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-            .image = depthImage,
+            .image = *depthImage,
             .subresourceRange = {
                 .aspectMask = vk::ImageAspectFlagBits::eDepth,
                 .baseMipLevel = 0,


### PR DESCRIPTION
Depth buffering for chapters 35 and 36 was missing. This PR adds it to those chapters.

Note: Chapter 34 (Android) is also missing depth buffer. But the code for that chapter is already pretty complicated, and getting depth buffer properly integrated looks like a bigger effort, so I did skip that.