### PR TITLE
docs: removed wrong information

### DIFF
--- a/en/00_Introduction.adoc
+++ b/en/00_Introduction.adoc
@@ -99,16 +99,11 @@ We will use C{pp} features like classes and RAII to organize logic and
 To make it easier to learn to work with Vulkan, we'll be using the newer
 https://github.com/KhronosGroup/Vulkan-Hpp[Vulkan-Hpp] bindings that
   abstract some of the dirty work and help prevent certain classes of errors.
-We'll also use Vulkan raii and the Vulkan C{pp}20 module. With this
+We'll also use Vulkan RAII and the Vulkan C{pp}20 module. With this
 combination, we show how to use Vulkan in a method that will translate
 directly into large projects where C{pp} libraries have traditionally caused
 large build times while also showing one method of making Vulkan a joy to
 work with.
-
-To make it easier to understand the core concepts and to follow along for
-developers using other programming languages, also to get some experience with
-the base API we'll be using the original C API when we describe the objects
-and the concepts that are being used.
 
 == License
 


### PR DESCRIPTION
* removed block containing "...we’ll be using the original C API..."
* capitalized "RAII"