### PR TITLE
Fixed typo in code snippet in 00_Base_code.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
@@ -140,7 +140,7 @@ can be directly replaced by this:
 vk::raii::Context context;
 constexpr auto appInfo = vk::ApplicationInfo("Hello Triangle", 1, "No Engine", 1, vk::ApiVersion11);
 vk::InstanceCreateInfo createInfo({}, &appInfo, {}, {});
-vk::raii::instance = std::make_unique<vk::raii::Instance>(context, createInfo);
+vk::raii::Instance = std::make_unique<vk::raii::Instance>(context, createInfo);
 ----
 
 As this can be a little hard to read when we look at the structures.  We have


### PR DESCRIPTION
I found just a simple typo. `vk::raii::instance` rather than `vk::raii::Instance`.