### PR TITLE
Fix: Set queue priority to 1.0f in all samples and docs

### DIFF
--- a/attachments/04_logical_device.cpp
+++ b/attachments/04_logical_device.cpp
@@ -211,7 +211,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = graphicsIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -229,7 +229,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -237,7 +237,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -238,7 +238,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -239,7 +239,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -249,7 +249,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -251,7 +251,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -252,7 +252,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -256,7 +256,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -265,7 +265,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -269,7 +269,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -302,7 +302,7 @@ class HelloTriangleApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -319,7 +319,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -323,7 +323,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -323,7 +323,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -330,7 +330,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -348,7 +348,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -353,7 +353,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -360,7 +360,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -363,7 +363,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -365,7 +365,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -378,7 +378,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -387,7 +387,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -387,7 +387,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -396,7 +396,7 @@ class HelloTriangleApplication
 		};
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -370,7 +370,7 @@ class ComputeShaderApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -525,7 +525,7 @@ class HelloTriangleApplication
 		features.pNext = pNext;
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{
 		         .pNext                   = &features,

--- a/attachments/33_vulkan_profiles.cpp
+++ b/attachments/33_vulkan_profiles.cpp
@@ -447,7 +447,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("Could not find a queue for graphics and present -> terminating");
 		}
 
-		float                     queuePriority = 1.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 
 		if (appInfo.profileSupported)

--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -583,7 +583,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("Could not find a queue for graphics and present -> terminating");
 		}
 
-		float                     queuePriority = 1.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 
 		if (appInfo.profileSupported)

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -594,7 +594,7 @@ class VulkanApplication
 		vulkan13Features.pNext                            = &extendedDynamicStateFeatures;
 		features.pNext                                    = &vulkan13Features;
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{
 		         .pNext                   = &features,

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -667,7 +667,7 @@ class VulkanApplication
 		vulkan13Features.pNext                            = &extendedDynamicStateFeatures;
 		features.pNext                                    = &vulkan13Features;
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{
 		         .pNext                   = &features,

--- a/attachments/37_multithreading.cpp
+++ b/attachments/37_multithreading.cpp
@@ -659,7 +659,7 @@ class MultithreadedApplication
 		vulkan13Features.pNext                            = &extendedDynamicStateFeatures;
 		features.pNext                                    = &vulkan13Features;
 
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = queueIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{
 		         .pNext                   = &features,

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -506,7 +506,7 @@ class VulkanRaytracingApplication
 		    };
 
 		// create a Device
-		float                     queuePriority = 0.0f;
+		float                     queuePriority = 0.5f;
 		vk::DeviceQueueCreateInfo deviceQueueCreateInfo{.queueFamilyIndex = graphicsIndex, .queueCount = 1, .pQueuePriorities = &queuePriority};
 		vk::DeviceCreateInfo      deviceCreateInfo{.pNext                   = &featureChain.get<vk::PhysicalDeviceFeatures2>(),
 		                                           .queueCreateInfoCount    = 1,

--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -59,7 +59,7 @@ This is required even if there is only a single queue:
 
 [,c++]
 ----
-float queuePriority = 0.0f;
+float queuePriority = 0.5f;
 vk::DeviceQueueCreateInfo deviceQueueCreateInfo { .queueFamilyIndex = graphicsIndex, .queueCount = 1, .pQueuePriorities = &queuePriority };
 ----
 

--- a/en/03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/00_Window_surface.adoc
@@ -267,7 +267,7 @@ void createLogicalDevice() {
     vulkan13Features.pNext = &extendedDynamicStateFeatures;
     features.pNext = &vulkan13Features;
     // create a Device
-    float                     queuePriority = 0.0f;
+    float                     queuePriority = 0.5f;
     vk::DeviceQueueCreateInfo deviceQueueCreateInfo { .queueFamilyIndex = graphicsIndex, .queueCount = 1, .pQueuePriorities = &queuePriority };
     vk::DeviceCreateInfo      deviceCreateInfo{ .pNext =  &features, .queueCreateInfoCount = 1, .pQueueCreateInfos = &deviceQueueCreateInfo };
     deviceCreateInfo.enabledExtensionCount = deviceExtensions.size();

--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
@@ -64,7 +64,7 @@ Alternatively, we can do this at the construction and keep this very succinct:
 [,c++]
 ----
 std::vector deviceExtensions = { vk::KHRSwapchainExtensionName };
-float                     queuePriority = 0.0f;
+float                     queuePriority = 0.5f;
 vk::DeviceQueueCreateInfo deviceQueueCreateInfo( {}, graphicsIndex, 1, &queuePriority );
 vk::DeviceCreateInfo      deviceCreateInfo( {}, deviceQueueCreateInfo, {}, deviceExtensions );
 ----


### PR DESCRIPTION
Replaced all instances of:
```cpp
float queuePriority = 0.0f;
```
with:
```cpp
float queuePriority = 1.0f;
```
Updated in both `.adoc` and `.cpp` files (33 total), to reflect best practice.

`1.0f` is the recommended queue priority, even in single-queue setups, to avoid confusion for beginners and ensure optimal execution priority.