### PR TITLE
Fix code snippets in 03_Physical_devices_and_queue_families.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.adoc
@@ -30,7 +30,7 @@ VkPhysicalDevice handle added as a new class member.
 
 [,c++]
 ----
-vk::raii::PhysicalDevice physicalDevice;
+vk::raii::PhysicalDevice physicalDevice = nullptr;
 ----
 
 Listing the graphics cards is very similar to listing extensions and starts with
@@ -189,7 +189,6 @@ void pickPhysicalDevice() {
                 found = found &&  extensionIter != extensions.end();
             }
             isSuitable = isSuitable && found;
-            printf("\n");
             if (isSuitable) {
                 physicalDevice = device;
             }


### PR DESCRIPTION
The physicalDevice member variable needs to be assigned to nullptr, otherwise the code won't compile.
There was a printf call that was just printing new lines.