### PR TITLE
Remove vk_platform include

### DIFF
--- a/attachments/00_base_code.cpp
+++ b/attachments/00_base_code.cpp
@@ -4,7 +4,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 #include <GLFW/glfw3.h>
 
 #include <iostream>

--- a/attachments/01_instance_creation.cpp
+++ b/attachments/01_instance_creation.cpp
@@ -10,8 +10,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/02_validation_layers.cpp
+++ b/attachments/02_validation_layers.cpp
@@ -12,8 +12,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/03_physical_device_selection.cpp
+++ b/attachments/03_physical_device_selection.cpp
@@ -12,8 +12,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/04_logical_device.cpp
+++ b/attachments/04_logical_device.cpp
@@ -13,8 +13,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -12,8 +12,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -14,8 +14,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -14,8 +14,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -14,8 +14,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -15,8 +15,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -16,8 +16,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -16,8 +16,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -16,8 +16,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -16,8 +16,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -17,8 +17,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -21,8 +21,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -17,7 +17,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>

--- a/attachments/33_vulkan_profiles.cpp
+++ b/attachments/33_vulkan_profiles.cpp
@@ -17,7 +17,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 #include <vulkan/vulkan_profiles.hpp>
 
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.

--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -17,7 +17,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 #if defined(__ANDROID__)
 #include <vulkan/vulkan_core.h>
 #include <vulkan/vulkan_android.h>

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -17,7 +17,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 #if defined(__ANDROID__)
 #include <vulkan/vulkan_core.h>
 #include <vulkan/vulkan_android.h>

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -17,7 +17,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 #if defined(__ANDROID__)
 #include <vulkan/vulkan_core.h>
 #include <vulkan/vulkan_android.h>

--- a/attachments/37_multithreading.cpp
+++ b/attachments/37_multithreading.cpp
@@ -22,7 +22,6 @@
 #else
 import vulkan_hpp;
 #endif
-#include <vulkan/vk_platform.h>
 
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -16,8 +16,6 @@
 import vulkan_hpp;
 #endif
 
-#include <vulkan/vk_platform.h>
-
 #define GLFW_INCLUDE_VULKAN // REQUIRED only for GLFW CreateWindowSurface.
 #include <GLFW/glfw3.h>
 


### PR DESCRIPTION
Removes the vk_platform.h include from all chapters. That header shouldn't be included explicitly and was already included implicitly anyway.

Fixes #148 