### PR TITLE
Use a profile that actually exists

### DIFF
--- a/en/13_Vulkan_Profiles.adoc
+++ b/en/13_Vulkan_Profiles.adoc
@@ -94,18 +94,18 @@ Instead of manually checking for features and extensions, you can define your pr
 
 [,c++]
 ----
-// Define the Best Practices profile
-const VpProfileProperties bestPracticesProfile = {
-    VP_BEST_PRACTICES_PROFILE_NAME,
-    VP_BEST_PRACTICES_PROFILE_SPEC_VERSION
+// Define the profile we want to use
+const VpProfileProperties profile = {
+    VP_KHR_ROADMAP_2022_NAME,
+    VP_KHR_ROADMAP_2022_SPEC_VERSION
 };
 
 // Check if the profile is supported
 VkBool32 supported = false;
-vpGetPhysicalDeviceProfileSupport(instance, physicalDevice, &bestPracticesProfile, &supported);
+vpGetPhysicalDeviceProfileSupport(instance, physicalDevice, &profile, &supported);
 
 if (!supported) {
-    throw std::runtime_error("Best Practices profile is not supported on this device");
+    throw std::runtime_error("Roadmap 2022 profile is not supported on this device");
 }
 ----
 
@@ -256,18 +256,18 @@ With profiles, all of that complexity is reduced to:
 [,c++]
 ----
 // Define the profile
-const VpProfileProperties bestPracticesProfile = {
-    VP_BEST_PRACTICES_PROFILE_NAME,
-    VP_BEST_PRACTICES_PROFILE_SPEC_VERSION
+const VpProfileProperties profile = {
+    VP_KHR_ROADMAP_2022_NAME,
+    VP_KHR_ROADMAP_2022_SPEC_VERSION
 };
 
 // Check if the profile is supported
 VkBool32 supported = false;
-vpGetPhysicalDeviceProfileSupport(instance, physicalDevice, &bestPracticesProfile, &supported);
+vpGetPhysicalDeviceProfileSupport(instance, physicalDevice, &profile, &supported);
 
 if (supported) {
     // Create device with the profile - all features enabled automatically
-    vpCreateDevice(physicalDevice, &deviceCreateInfo, &bestPracticesProfile, nullptr, &device);
+    vpCreateDevice(physicalDevice, &deviceCreateInfo, &profile, nullptr, &device);
 
     // Now we can use any feature guaranteed by the profile without checks
     // For example, dynamic rendering is always available:


### PR DESCRIPTION
This PR replaces the imaginary 'VP_BEST_PRACTICES_PROFILE` (which does not exist) with an actual profile.

Fixes #140