### PR TITLE
Add type definition to validation layer vector

### DIFF
--- a/attachments/02_validation_layers.cpp
+++ b/attachments/02_validation_layers.cpp
@@ -20,7 +20,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/03_physical_device_selection.cpp
+++ b/attachments/03_physical_device_selection.cpp
@@ -20,7 +20,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/04_logical_device.cpp
+++ b/attachments/04_logical_device.cpp
@@ -21,7 +21,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -20,7 +20,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -22,7 +22,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -22,7 +22,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -22,7 +22,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -23,7 +23,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -23,7 +23,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -23,7 +23,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -23,7 +23,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -23,7 +23,7 @@ import vulkan_hpp;
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -24,7 +24,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -24,7 +24,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -26,7 +26,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -26,7 +26,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -26,7 +26,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -26,7 +26,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -30,7 +30,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -30,7 +30,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -33,7 +33,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -33,7 +33,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -33,7 +33,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -34,7 +34,7 @@ constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -42,7 +42,7 @@ const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -42,7 +42,7 @@ const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -42,7 +42,7 @@ const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -37,7 +37,7 @@ constexpr uint32_t PARTICLE_COUNT = 8192;
 
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -50,7 +50,7 @@ constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/plant_on_table.obj";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
@@ -93,7 +93,7 @@ is part of the c{pp} standard and means "not debug".
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
 
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 

--- a/en/12_Ecosystem_Utilities_and_Compatibility.adoc
+++ b/en/12_Ecosystem_Utilities_and_Compatibility.adoc
@@ -103,7 +103,7 @@ In many Vulkan applications, validation layers are enabled programmatically duri
 [,c++]
 ----
 // Define validation layers
-const std::vector validationLayers = {
+const std::vector<char const*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"
 };
 


### PR DESCRIPTION
The vector for validation layers was the only vector not having type declarations. While that does seem to compile fine with most compilers, it's confusing, esp. as other vectors do have type declarations.

To bring this in line with the rest of the tutorial, this PR adds a proper type declaration.

Fixes #125