### PR TITLE
Remove FenceTimeout

### DIFF
--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -37,7 +37,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -37,7 +37,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -37,7 +37,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -32,7 +32,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 constexpr uint32_t PARTICLE_COUNT = 8192;
 
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -37,7 +37,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
@@ -1521,7 +1520,7 @@ private:
     }
 
     void drawFrame() {
-        while (vk::Result::eTimeout == device.waitForFences(*inFlightFences[currentFrame], vk::True, FenceTimeout))
+        while (vk::Result::eTimeout == device.waitForFences(*inFlightFences[currentFrame], vk::True, UINT64_MAX))
             ;
         auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphore[currentFrame], nullptr);
 

--- a/attachments/33_vulkan_profiles.cpp
+++ b/attachments/33_vulkan_profiles.cpp
@@ -38,7 +38,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
@@ -1520,11 +1519,11 @@ private:
     }
 
     void drawFrame() {
-        static_cast<void>(device.waitForFences({*inFlightFences[currentFrame]}, VK_TRUE, FenceTimeout));
+        static_cast<void>(device.waitForFences({*inFlightFences[currentFrame]}, VK_TRUE, UINT64_MAX));
 
         uint32_t imageIndex;
         try {
-            auto [result, idx] = swapChain.acquireNextImage(FenceTimeout, *imageAvailableSemaphores[currentFrame]);
+            auto [result, idx] = swapChain.acquireNextImage(UINT64_MAX, *imageAvailableSemaphores[currentFrame]);
             imageIndex = idx;
         } catch (vk::OutOfDateKHRError&) {
             recreateSwapChain();

--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -86,7 +86,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
@@ -1256,11 +1255,11 @@ private:
 
     // Draw frame
     void drawFrame() {
-        static_cast<void>(device.waitForFences({*inFlightFences[currentFrame]}, VK_TRUE, FenceTimeout));
+        static_cast<void>(device.waitForFences({*inFlightFences[currentFrame]}, VK_TRUE, UINT64_MAX));
 
         uint32_t imageIndex;
         try {
-            auto [result, idx] = swapChain.acquireNextImage(FenceTimeout, *imageAvailableSemaphores[currentFrame]);
+            auto [result, idx] = swapChain.acquireNextImage(UINT64_MAX, *imageAvailableSemaphores[currentFrame]);
             imageIndex = idx;
         } catch (vk::OutOfDateKHRError&) {
             recreateSwapChain();

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -79,7 +79,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 // Update paths to use glTF model and KTX2 texture
 const std::string MODEL_PATH = "models/viking_room.glb";
 const std::string TEXTURE_PATH = "textures/viking_room.ktx2";

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -79,7 +79,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 // Update paths to use glTF model and KTX2 texture
 const std::string MODEL_PATH = "models/viking_room.glb";
 const std::string TEXTURE_PATH = "textures/viking_room.ktx2";

--- a/attachments/37_multithreading.cpp
+++ b/attachments/37_multithreading.cpp
@@ -33,7 +33,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 constexpr uint32_t PARTICLE_COUNT = 8192;
 
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -46,7 +46,6 @@ import vulkan_hpp;
 
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/plant_on_table.obj";
 constexpr int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/en/08_Loading_models.adoc
+++ b/en/08_Loading_models.adoc
@@ -40,7 +40,6 @@ Put two new configuration variables in your program to define the model and text
 ----
 constexpr uint32_t WIDTH = 800;
 constexpr uint32_t HEIGHT = 600;
-constexpr uint64_t FenceTimeout = 100000000;
 const std::string MODEL_PATH = "models/viking_room.obj";
 const std::string TEXTURE_PATH = "textures/viking_room.png";
 ----

--- a/en/11_Compute_Shader.adoc
+++ b/en/11_Compute_Shader.adoc
@@ -623,7 +623,7 @@ We then use these to synchronize the compute buffer submission with the graphics
 ----
 {
     // Compute submission
-    while ( vk::Result::eTimeout == device->waitForFences( **computeInFlightFences[currentFrame], vk::True, FenceTimeout ) )
+    while ( vk::Result::eTimeout == device->waitForFences(**computeInFlightFences[currentFrame], vk::True, UINT64_MAX) )
         ;
 
     updateUniformBuffer(currentFrame);
@@ -636,7 +636,7 @@ We then use these to synchronize the compute buffer submission with the graphics
 }
 {
     // Graphics submission
-    while ( vk::Result::eTimeout == device->waitForFences( **inFlightFences[currentFrame], vk::True, FenceTimeout ) )
+    while ( vk::Result::eTimeout == device->waitForFences(**inFlightFences[currentFrame], vk::True, UINT64_MAX))
 ...
 
     device->resetFences(  **inFlightFences[currentFrame] );


### PR DESCRIPTION
Several samples had a variable called `FenceTimeout` declared, but never actually used it. Few samples did use it, but mixed it inconsistently with UINT64_MAX.

This PR removes that unnecessary variable, making the code more consistent.