### PR TITLE
Add link to the GitHub repository to the navigation sidebar

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -62,3 +62,4 @@
 ** xref:courses/18_Ray_tracing/06_Reflections.adoc[Reflections]
 ** xref:courses/18_Ray_tracing/07_Conclusion.adoc[Conclusion]
 * xref:90_FAQ.adoc[FAQ]
+* link:https://github.com/KhronosGroup/Vulkan-Tutorial[GitHub Repository, window=_blank]


### PR DESCRIPTION
This PR adds a link to the GitHub repository to the left side navigation. That should make it easier for people to find the actual code for the tutorial.