### PR TITLE
Update 04_Logical_device_and_queues.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/04_Logical_device_and_queues.adoc
@@ -15,7 +15,7 @@ Start by adding a new class member to store the logical device handle in.
 
 [,c++]
 ----
-vk::raii::Device device;
+vk::raii::Device device = nullptr;
 ----
 
 Next, add a `createLogicalDevice` function that is called from `initVulkan`.
@@ -44,7 +44,7 @@ Right now we're only interested in a queue with graphics capabilities.
 [,c++]
 ----
 std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
-
+uint32_t graphicsIndex = findQueueFamilies(m_physicalDevice);
 vk::DeviceQueueCreateInfo deviceQueueCreateInfo { .queueFamilyIndex = graphicsIndex };
 ----
 


### PR DESCRIPTION
vk::raii::Device has a deleted default constructor, but does have a Device(std::nullptr_t) constructor. Also make it clear where graphicsIndex is coming from (findQueueFamilies from the previous chapter).