### PR TITLE
Add depth buffering to chapter 34

### DIFF
--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -1630,7 +1630,7 @@ class HelloTriangleApplication
 		    .allocationSize  = memRequirements.size,
 		    .memoryTypeIndex = findMemoryType(memRequirements.memoryTypeBits, properties)};
 		imageMemory = vk::raii::DeviceMemory(device, allocInfo);
-		image.bindMemory(imageMemory, 0);
+		image.bindMemory(*imageMemory, 0);
 	}
 
 	// Transition image layout


### PR DESCRIPTION
This PR adds proper depth buffering to chapter 34. Without this fix, the model isn't rendered properly.

I also made parts of the code match the rest of the tutorial, esp. stuff regarding image creation (which differed from the way other chapters do it).

None of the code touched by this is mentioned in the tutorial text, so no need to update the text for the chapter.

Fixes #164
