### PR TITLE
Update 00_Base_code chapter to Vulkan-hpp code we actually use in our code

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.adoc
@@ -148,9 +148,11 @@ constexpr vk::ApplicationInfo appInfo{ .pApplicationName   = "Hello Triangle",
     .pEngineName        = "No Engine",
     .engineVersion      = VK_MAKE_VERSION( 1, 0, 0 ),
     .apiVersion         = vk::ApiVersion14 };
+
 vk::InstanceCreateInfo createInfo{
     .pApplicationInfo = &appInfo
 };
+
 instance = vk::raii::Instance(context, createInfo);
 ----
 


### PR DESCRIPTION
This PR updates the 00_Base_code chapter to use the C++ Instance setup code we actually use in our code. Also adds a bit of clarification around enabling designated initializers for Vulkan-hpp and puts that into an easier to spot "NOTE" block.