### PR TITLE
Rework depth buffer chapter

### DIFF
--- a/en/07_Depth_buffering.adoc
+++ b/en/07_Depth_buffering.adoc
@@ -184,7 +184,7 @@ vk::Format findSupportedFormat(const std::vector<vk::Format>& candidates, vk::Im
 ----
 
 The support of a format depends on the tiling mode and usage, so we must also include these as parameters.
-The support of a format can be queried using the `vkGetPhysicalDeviceFormatProperties` function:
+The support of a format can be queried using the `physicalDevice.getFormatProperties` function:
 
 [,c++]
 ----


### PR DESCRIPTION
This PR reworks the depth buffer chapter. That one was still pretty much the same as in the original tutorial. Meaning it still referenced things like render passes or framebuffers we no longer use due to dynamic rendering. Due to that it didn't match our code at all.

So with this PR I did the following:

- No more render passes
- No more framebuffers
- Dynamic rendering
- Explicit barriers
- Some rewording and additions to clarify things
- Use vulkan-hpp names

Fixes #210 