### PR TITLE
docs: added try-catch code in swapchain recreation chapter

### DIFF
--- a/en/03_Drawing_a_triangle/04_Swap_chain_recreation.adoc
+++ b/en/03_Drawing_a_triangle/04_Swap_chain_recreation.adoc
@@ -149,7 +149,7 @@ catch (const vk::SystemError &e)
 }
 ----
 
-Recent versions of the Vulkan CPP header throw exceptions on unsuccessful return codes. To handle exceptions thrown by `vkQueuePresentKHR`, catch `vk::SystemError` and check the error code as shown above.
+Recent versions of Vulkan-hpp throw exceptions on unsuccessful return codes. To handle exceptions thrown by `vkQueuePresentKHR`, catch `vk::SystemError` and check the error code as shown above.
 
 == Fixing a deadlock
 


### PR DESCRIPTION
Added a snippet of C++ code which handles exceptions thrown by `vkQueuePresentKHR` in the swapchain recreation chapter.
The snippet was already present in the attached code, but absent from the tutorial text.
Not using the try-catch, as shown in the tutorial, will break the program while resizing the window on some machines.