### PR TITLE
Add build folders for simple game engine to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,15 @@ attachments/android/.gradle/**
 attachments/android/app/.cxx/**
 attachments/android/app/build/**
 local.properties
+
+attachments/simple_engine/build/**
+attachments/simple_engine/Assets/**
+attachments/simple_engine/android/.gradle/**
+attachments/simple_engine/android/.idea
+attachments/simple_engine/android/.gradle/**
+attachments/simple_engine/android/app/.cxx/**
+attachments/simple_engine/android/app/build/**
+attachments/simple_engine/android/app/build/**
+attachments/simple_engine/android/gradle/wrapper/**
+attachments/simple_engine/android/gradlew
+attachments/simple_engine/android/gradlew.bat


### PR DESCRIPTION
This PR adds folders and files to the .gitignore that are created during build time for the simple game engine. These should not be part of version control, and having them ignored ensures that maintainers don't accidently push them to the repo.