### PR TITLE
Fix deadlock on swapchain recreation

### DIFF
--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -510,7 +510,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -524,6 +523,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("failed to acquire swap chain image!");
 		}
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/18_vertex_input.cpp
+++ b/attachments/18_vertex_input.cpp
@@ -529,7 +529,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -543,6 +542,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("failed to acquire swap chain image!");
 		}
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -565,7 +565,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -579,6 +578,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("failed to acquire swap chain image!");
 		}
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -585,7 +585,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -599,6 +598,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("failed to acquire swap chain image!");
 		}
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -611,7 +611,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -625,6 +624,7 @@ class HelloTriangleApplication
 			throw std::runtime_error("failed to acquire swap chain image!");
 		}
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -670,7 +670,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -685,6 +684,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -698,7 +698,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -713,6 +712,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -807,7 +807,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -822,6 +821,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -843,7 +843,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -858,6 +857,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -908,7 +908,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -923,6 +922,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -1009,7 +1009,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1024,6 +1023,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -1065,7 +1065,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1080,6 +1079,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -1135,7 +1135,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1150,6 +1149,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -1198,7 +1198,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1213,6 +1212,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -1589,7 +1589,6 @@ class HelloTriangleApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1604,6 +1603,7 @@ class HelloTriangleApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -1398,7 +1398,6 @@ class VulkanApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1413,6 +1412,7 @@ class VulkanApplication
 		}
 		updateUniformBuffer(frameIndex);
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -1531,7 +1531,6 @@ class VulkanApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1548,6 +1547,7 @@ class VulkanApplication
 		// Update uniform buffers for all objects
 		updateUniformBuffers();
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -1828,7 +1828,6 @@ class VulkanRaytracingApplication
 		{
 			throw std::runtime_error("failed to wait for fence!");
 		}
-		device.resetFences(*inFlightFences[frameIndex]);
 
 		auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
 
@@ -1847,6 +1846,7 @@ class VulkanRaytracingApplication
 		updateTopLevelAS(ubo.model);
 #endif        // LAB_TASK_LEVEL >= LAB_TASK_AS_ANIMATION
 
+		device.resetFences(*inFlightFences[frameIndex]);
 		commandBuffers[frameIndex].reset();
 		recordCommandBuffer(imageIndex);
 


### PR DESCRIPTION
I'm working through the Vulkan tutorial and noticed the following.

In the deadlock section: https://docs.vulkan.org/tutorial/latest/03_Drawing_a_triangle/04_Swap_chain_recreation.html#_fixing_a_deadlock

It gives the example of a deadlock where the device fence is reset and the `drawFrame` function is exited early. On the next call to `drawFrame`, the call to `waitForFences` never returns, as the fence is left in an unsignaled state without anything to signal it.

The tutorial docs seem correct in that explanation, but the C++ code attachment still has the deadlock condition.

This fixes the C++ attachments where I was able to find the deadlocking code still present.

Now we reset the fence when we are ready to use it. The location was chosen to match attachments where the deadlock does not appear, or was already in the right location.