### PR TITLE
Fix variable name from 'extension' to 'extensions'

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/01_Instance.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/01_Instance.adoc
@@ -211,7 +211,7 @@ ignore for now.
 
 [,c++]
 ----
-auto extension = context.enumerateInstanceExtensionProperties();
+auto extensions = context.enumerateInstanceExtensionProperties();
 ----
 
 Each `VkExtensionProperties` struct contains the name and version of an


### PR DESCRIPTION
This vector is referred in the next section as 'extensions'