### PR TITLE
Update 04_Conclusion.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.adoc
@@ -11,7 +11,6 @@ Here are the types of objects we have now, as a quick recap:
 * Dynamic rendering: the formats of the attachments that will be used during rendering
 
 All of these combined fully define the functionality of the graphics pipeline, so we can now begin filling in the `VkGraphicsPipelineCreateInfo` structure at the end of the `createGraphicsPipeline` function.
-But before the calls to  `vkDestroyShaderModule` because these are still to be used during the creation.
 
 [,c++]
 ----


### PR DESCRIPTION
Removed a reference to vkDestroyShaderModule as this sentence seems to be a remnant from the original guide and doesn't seem to be relevant here. Also the subsequent text on pipelineInfo seems redundant as this was already covered in previous chapter.