### PR TITLE
Removed unnecessary declarations of rasterizer. They just disturbed t…

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/02_Fixed_functions.adoc
@@ -171,29 +171,12 @@ The following modes are available:
 
 Using any mode other than fill requires enabling a GPU feature.
 
-[,c++]
-----
-rasterizer.lineWidth = 1.0f;
-----
-
 The `lineWidth` member is straightforward, it describes the thickness of lines in terms of number of fragments.
 The maximum line width that is supported depends on the hardware and any line thicker than `1.0f` requires you to enable the `wideLines` GPU feature.
-
-[,c++]
-----
-vk::PipelineRasterizationStateCreateInfo rasterizer({}, vk::False, vk::False, vk::PolygonMode::eFill,
-        vk::CullModeFlagBits::eBack, vk::FrontFace::eClockwise);
-----
 
 The `cullMode` variable determines the type of face culling to use.
 You can disable culling, cull the front faces, cull the back faces or both.
 The `frontFace` variable specifies the vertex order for the faces to be considered front-facing and can be clockwise or counterclockwise.
-
-[,c++]
-----
-vk::PipelineRasterizationStateCreateInfo rasterizer({}, vk::False, vk::False, vk::PolygonMode::eFill,
-        vk::CullModeFlagBits::eBack, vk::FrontFace::eClockwise, vk::False);
-----
 
 The rasterizer can alter the depth values by adding a constant value or biasing them based on a fragment's slope.
 This is sometimes used for shadow mapping, but we won't be using it.


### PR DESCRIPTION
The initial declarations of rasterizer didn't compile and IMHO only disturbed the meaning. Changed to a single declaration and condensed the explation of the fields just below the declaration.