### PR TITLE
Fix list rendering inside table cells

### DIFF
--- a/en/Building_a_Simple_Engine/Appendix/appendix.adoc
+++ b/en/Building_a_Simple_Engine/Appendix/appendix.adoc
@@ -238,47 +238,47 @@ Below is a comparative analysis of the architectural patterns discussed in this 
 | Pattern | Strengths | Weaknesses | Best Used For
 
 | Layered Architecture
-| * Clear separation of concerns
+a| * Clear separation of concerns
   * Easy to understand
   * Good for beginners
-| * Can lead to "layer bloat"
+a| * Can lead to "layer bloat"
   * May introduce unnecessary indirection
   * Potential performance overhead from layer traversal
-| * Smaller engines
+a| * Smaller engines
   * Educational projects
   * When clarity is more important than performance
 
 | Component-Based Architecture
-| * Highly flexible and modular
+a| * Highly flexible and modular
   * Promotes code reuse
   * Avoids deep inheritance hierarchies
   * Easier to extend with new features
-| * More complex to implement initially
+a| * More complex to implement initially
   * Can be harder to debug
   * Potential performance overhead from component lookups
-| * Modern rendering engines
+a| * Modern rendering engines
   * Systems with diverse object types
   * Projects requiring frequent extension
 
 | Data-Oriented Design
-| * Excellent performance
+a| * Excellent performance
   * Cache-friendly memory access
   * Good for parallel processing
-| * Less intuitive than OOP
+a| * Less intuitive than OOP
   * Steeper learning curve
   * Can make code harder to read
-| * Performance-critical systems
+a| * Performance-critical systems
   * Mobile platforms
   * Systems processing large amounts of similar data
 
 | Service Locator Pattern
-| * Decouples service providers from consumers
+a| * Decouples service providers from consumers
   * Facilitates testing
   * Allows runtime service swapping
-| * Can hide dependencies
+a| * Can hide dependencies
   * Potential for runtime errors
   * Global state concerns
-| * Cross-cutting concerns
+a| * Cross-cutting concerns
   * Systems requiring runtime configuration
   * When loose coupling is critical
 |===


### PR DESCRIPTION
Asciidoc doesn't apply formatting in table cells by default, rendering intended lists as plain text. This PR adds the proper markdown to make the lists entries show up as intended.