### PR TITLE
Fix the use of presentCompleteSemaphore

### DIFF
--- a/en/03_Drawing_a_triangle/03_Drawing/02_Rendering_and_presentation.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/02_Rendering_and_presentation.adoc
@@ -230,7 +230,7 @@ finished:
 ----
 void drawFrame() {
     ...
-    auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphores[frameIndex], nullptr);
+    auto [result, imageIndex] = swapChain.acquireNextImage(UINT64_MAX, *presentCompleteSemaphore, nullptr);
 }
 ----
 
@@ -240,7 +240,7 @@ Using the maximum value of a 64-bit unsigned integer means we effectively disabl
 The next two parameters specify synchronization objects that are to be signaled when the presentation engine is finished using the image.
 That's the point in time where we can start drawing to it.
 It is possible to specify a semaphore, fence or both.
-We're going to use our `presentCompleteSemaphores` for that purpose here.
+We're going to use our `presentCompleteSemaphore` for that purpose here.
 
 The last parameter specifies a variable to output the index of the swap chain image that has become available.
 The index refers to the `VkImage` in our `swapChainImages` array.


### PR DESCRIPTION
It was probably a typo but presentCompleteSemaphores[] was used instead which conflicted with previous steps and the provided source code.