### PR TITLE
Typo fix: Rename Rendergraph::ImageResource to Resource

### DIFF
--- a/en/Building_a_Simple_Engine/Engine_Architecture/05_rendering_pipeline.adoc
+++ b/en/Building_a_Simple_Engine/Engine_Architecture/05_rendering_pipeline.adoc
@@ -132,7 +132,7 @@ class Rendergraph {
 private:
     // Resource description and management structure
     // Represents Image resource used during rendering (textures)
-    struct ImageResource {
+    struct Resource {
         std::string name;                     // Human-readable identifier for debugging and referencing
         vk::Format format;                    // Pixel format (RGBA8, Depth24Stencil8, etc.)
         vk::Extent2D extent;                  // Dimensions in pixels for 2D resources


### PR DESCRIPTION
Renamed the struct declaration as the rest of the code refers to it as `Resource` instead of `ImageResource`. Alternatively the other parts of the code using it could be updated if `ImageResource` is preferred.