### PR TITLE
Add #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS

### DIFF
--- a/attachments/01_instance_creation.cpp
+++ b/attachments/01_instance_creation.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <stdexcept>
-
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
 #if defined(__INTELLISENSE__) || !defined(USE_CPP20_MODULES)
 #	include <vulkan/vulkan_raii.hpp>
 #else


### PR DESCRIPTION
After reviewing the source code, I found that 
**without this macro definition, a custom constructor will be added to the `vk::ApplicationInfo` struct.**

If a constructor is added, then `vk::ApplicationInfo` is no longer an aggregate class. In this case, it's no longer possible to use **Designated Initializers**, i.e., assign values ​​to members using `.member = value`.

**Source code path**: VulkanSDK\1.4.341.1\Include\vulkan\vulkan_structs.hpp
**Code excerpts**:
```cpp
#if !defined( VULKAN_HPP_NO_CONSTRUCTORS ) && !defined( VULKAN_HPP_NO_STRUCT_CONSTRUCTORS ) 
VULKAN_HPP_CONSTEXPR ApplicationInfo( const char * pApplicationName_ = {}, 
uint32_t applicationVersion_ = {}, 
const char * pEngineName_ = {}, 
uint32_t engineVersion_ = {}, 
uint32_t apiVersion_ = {}, 
const void * pNext_ = nullptr ) VULKAN_HPP_NOEXCEPT 
: pNext{ pNext_ } 
, pApplicationName{ pApplicationName_ } 
, applicationVersion{ applicationVersion_ } , pEngineName{ pEngineName_ }

, engineVersion{ engineVersion_ }

, apiVersion{ apiVersion_ }

{
}
```

I am using the VS 2020 Enterprise version, when I configured it exactly according to the tutorial. I discovered this problem by observing an error message in Visual Studio that reads something like "error C7555: use of designated initializers requires an aggregate class type".