### PR TITLE
Fixed the valid Layer error and black screen issue in 23_descriptor_s…

### DIFF
--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -434,7 +434,7 @@ class HelloTriangleApplication
 		                                                    .rasterizerDiscardEnable = vk::False,
 		                                                    .polygonMode             = vk::PolygonMode::eFill,
 		                                                    .cullMode                = vk::CullModeFlagBits::eBack,
-		                                                    .frontFace               = vk::FrontFace::eClockwise,
+		                                                    .frontFace               = vk::FrontFace::eCounterClockwise,
 		                                                    .depthBiasEnable         = vk::False,
 		                                                    .lineWidth               = 1.0f};
 
@@ -450,7 +450,10 @@ class HelloTriangleApplication
 		std::vector<vk::DynamicState>      dynamicStates = {vk::DynamicState::eViewport, vk::DynamicState::eScissor};
 		vk::PipelineDynamicStateCreateInfo dynamicState{.dynamicStateCount = static_cast<uint32_t>(dynamicStates.size()), .pDynamicStates = dynamicStates.data()};
 
-		vk::PipelineLayoutCreateInfo pipelineLayoutInfo{.setLayoutCount = 0, .pushConstantRangeCount = 0};
+		vk::PipelineLayoutCreateInfo pipelineLayoutInfo{
+			.setLayoutCount = 1,
+			.pSetLayouts=&*descriptorSetLayout,
+			.pushConstantRangeCount = 0};
 		pipelineLayout = vk::raii::PipelineLayout(device, pipelineLayoutInfo);
 
 		vk::StructureChain<vk::GraphicsPipelineCreateInfo, vk::PipelineRenderingCreateInfo> pipelineCreateInfoChain = {


### PR DESCRIPTION
## Issues & Fixes

### 1. Validation Error: Missing Descriptor Set Layout

**Error:**

```text
validation layer: type { Validation } msg: vkCreateGraphicsPipelines(): pCreateInfos[0].pStages[0] SPIR-V (VK_SHADER_STAGE_VERTEX_BIT) uses descriptor [Set 0, Binding 0, variable "ubo"] but the binding was not declared in the VkPipelineLayoutCreateInfo::pSetLayouts[0].
```

**Cause:**
I think this is the validation layer telling you that the shader declared a UBO with set=0 (if not specified, it's the default), binding=0, but there's no layout with set 0 in the pipeline layout. 

**Fix:**
I fixed the creation of pipelineLayoutInfo.

---

### 2. The window was completely black.

**Cause:**
I found that the triangle composed of indices 0, 1, 2 was rotating counterclockwise on the screen, while you set the front side to clockwise, and the back side culling took effect, so this triangle was discarded.

**Fix:**
I modified the rasterizer's creation.


