### PR TITLE
Bump KTX to 4.4.2

### DIFF
--- a/attachments/CMake/FindKTX.cmake
+++ b/attachments/CMake/FindKTX.cmake
@@ -87,7 +87,7 @@ else()
   FetchContent_Declare(
     ktx
     GIT_REPOSITORY https://github.com/KhronosGroup/KTX-Software.git
-    GIT_TAG v4.3.1  # Use a specific tag for stability
+    GIT_TAG v4.4.2  # Use a specific tag for stability
   )
 
   # Set options to minimize build time and dependencies


### PR DESCRIPTION
Compiling with Clang fails with version 4.3.1 of KTX (`clang++: error: overriding '-ffp-model=precise' option with '-ffp-contract=off' [-Werror,-Woverriding-option]`). Version 4.4.0 fixed this error. This commit bumps it to the latest version, 4.4.2 (published October 2025)