### PR TITLE
Added coming soon links for SIGGRAPH2026

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -61,6 +61,7 @@
 ** xref:courses/18_Ray_tracing/05_Shadow_transparency.adoc[Shadow transparency]
 ** xref:courses/18_Ray_tracing/06_Reflections.adoc[Reflections]
 ** xref:courses/18_Ray_tracing/07_Conclusion.adoc[Conclusion]
+* xref:courses/siggraph2026_vk_tutorial/00_Overview.adoc[How to write a Vulkan application in 2026]
 * xref:90_FAQ.adoc[FAQ]
 * link:https://github.com/KhronosGroup/Vulkan-Tutorial[GitHub Repository, window=_blank]
 

--- a/en/courses/18_Ray_tracing/00_Overview.adoc
+++ b/en/courses/18_Ray_tracing/00_Overview.adoc
@@ -5,6 +5,7 @@
 Welcome! In this series, we enhance a Vulkan renderer with ray tracing features to implement real-time pixel-perfect shadows (with and without transparency) and a bonus reflection effect. You will work with provided scaffolded code (based on the Vulkan Tutorial) and fill in key shader functions following step-by-step instructions.
 
 Slides available link:/attachments/Vulkan%20Ray%20Tracing%20With%20Dynamic%20Rendering.pdf[here].
+Source code available link:https://github.com/KhronosGroup/Vulkan-Tutorial/blob/main/attachments/38_ray_tracing.cpp[here].
 
 By the end, you'll learn how to:
 

--- a/en/courses/siggraph2026_vk_tutorial/00_Overview.adoc
+++ b/en/courses/siggraph2026_vk_tutorial/00_Overview.adoc
@@ -1,0 +1,38 @@
+= SIGGRAPH 2026: How to write a Vulkan application in 2026
+
+== Overview
+
+Welcome! In this series, we will explain how to write a Vulkan renderer using new Vulkan extensions and the recommended best practices from Khronos as of 2026. This tutorial uses shader objects, dynamic rendering, and descriptor heap techniques, and is based on our SIGGRAPH 2026 course "How to write a Vulkan application in 2026".
+
+Slides available: Coming soon.
+Source code available: Coming soon.
+
+By the end, you'll learn how to:
+
+- Design and implement 2026 Vulkan applications using up-to-date extensions.
+- Modernize existing Vulkan applications by identifying legacy Vulkan 1.0 patterns and replacing them with simpler alternatives.
+- Evaluate which Vulkan extensions are appropriate for simplifying application design and improving developer productivity.
+- Distinguish between legacy and recommended Vulkan approaches, understanding which techniques to avoid and why.
+- Use recent Vulkan features such as descriptor heap, dynamic rendering, and related extensions.
+
+*Please visit us at SIGGRAPH 2026*:
+
+SIGGRAPH page:
+- https://s2026.conference-schedule.org/presentation/?id=gensub_276&sess=sess202
+
+Session details (from the SIGGRAPH listing):
+
+- Course Title: How to write a Vulkan application in 2026
+- Course Date and Time: Wed Jul 22, 9am-12:15pm PDT
+- Course Location: Petree D
+- Interest Areas: Gaming & Interactive
+- Keywords: Education, Games, Real-Time, Rendering
+
+*Prerequisites*:
+This course primarily targets developers with little to no prior Vulkan experience. The intended audience is programmers with some background in computer graphics, possibly including experience with APIs such as OpenGL or DirectX, who are seeking an introduction to Vulkan.
+
+Familiarity with C++ is expected. Some familiarity with graphics programming concepts (e.g., shaders, rendering pipelines) is helpful but not strictly required, as the course will cover these topics in the context of Vulkan.
+
+== Chapters in this series
+
+- Coming soon.

--- a/en/courses/siggraph2026_vk_tutorial/README.adoc
+++ b/en/courses/siggraph2026_vk_tutorial/README.adoc
@@ -25,7 +25,7 @@ Co-authors:
 
 Attribution:
 
-- The instructional flow and lab content here are adapted from the above SIGGRAPH 2026 lab. Please cite the authors above when referencing or reusing this material.
-- Portions of the code and guidance build upon the open-source Khronos Vulkan Tutorial and use helper libraries like Vulkan-RAII, as referenced in the lab description.
+- The instructional flow and course content here are adapted from the above SIGGRAPH 2026 course. Please cite the authors above when referencing or reusing this material.
+- We would like to thank all Khronos Group members and the countless open source contributors to the Vulkan ecosystem, including libraries like vk-bootstrap and Vulkan-Hpp that made this course possible.
 
 If you notice any discrepancy with the official SIGGRAPH listing (title, time, location, or presenters), please open an issue so we can correct the attribution promptly.

--- a/en/courses/siggraph2026_vk_tutorial/README.adoc
+++ b/en/courses/siggraph2026_vk_tutorial/README.adoc
@@ -1,0 +1,31 @@
+= SIGGRAPH 2026: How to write a Vulkan application in 2026 - Attribution
+
+This folder contains the courseware for "SIGGRAPH 2026: How to write a Vulkan application in 2026".
+
+SIGGRAPH page:
+- https://s2026.conference-schedule.org/presentation/?id=gensub_276&sess=sess202
+
+Session details (from the SIGGRAPH listing):
+
+- Course Title: How to write a Vulkan application in 2026
+- Course Date and Time: Wed Jul 22, 9am-12:15pm PDT
+- Course Location: Petree D
+- Interest Areas: Gaming & Interactive
+- Keywords: Education, Games, Real-Time, Rendering
+
+Authors / Presenters:
+
+- Iago Calvo Lista (Arm)
+- Jose Emilio Muñoz Lopez (Arm)
+- Ralph Potter (Samsung & Khronos Group)
+
+Co-authors:
+
+- Elvar Unnthorsson (Arm)
+
+Attribution:
+
+- The instructional flow and lab content here are adapted from the above SIGGRAPH 2026 lab. Please cite the authors above when referencing or reusing this material.
+- Portions of the code and guidance build upon the open-source Khronos Vulkan Tutorial and use helper libraries like Vulkan-RAII, as referenced in the lab description.
+
+If you notice any discrepancy with the official SIGGRAPH listing (title, time, location, or presenters), please open an issue so we can correct the attribution promptly.


### PR DESCRIPTION
Added a temporary coming soon document for the SIGGRAPH2026 course: How to write a Vulkan application in 2026.

This link will be included as part of the slides submitted to the SIGGRAPH library.
Once the slides, code and materials are ready, we will replace the documents with the proper version.