### PR TITLE
docs: replace "link:" with "xref:" for internal page references

### DIFF
--- a/en/08_Loading_models.adoc
+++ b/en/08_Loading_models.adoc
@@ -15,7 +15,7 @@ We _will_ load mesh data from an OBJ model in this chapter, but we'll focus more
 
 We will use the https://github.com/syoyo/tinyobjloader[tinyobjloader] library to load vertices and faces from an OBJ file.
 It's fast and it's easy to integrate because it's a single file library like stb_image.
-This was mentioned in the link:02_Development_environment.adoc[Development Environment] chapter and should be part of the dependencies for this portion of the tutorial.
+This was mentioned in the xref:02_Development_environment.adoc[Development Environment] chapter and should be part of the dependencies for this portion of the tutorial.
 
 == Sample mesh
 

--- a/en/18_Ray_tracing.adoc
+++ b/en/18_Ray_tracing.adoc
@@ -1,3 +1,3 @@
 == SIGGRAPH 2025: Hands-on Vulkan Ray Tracing with Dynamic Rendering
 
-Find the course link:courses/18_Ray_tracing/00_Overview.adoc[here]
+Find the course xref:courses/18_Ray_tracing/00_Overview.adoc[here]

--- a/en/conclusion.adoc
+++ b/en/conclusion.adoc
@@ -41,7 +41,7 @@ Throughout this tutorial series, you've gained knowledge and practical experienc
 This tutorial series has provided you with the essential tools for more
 advanced Vulkan development. With these fundamentals mastered, you're now ready to explore more complex topics and build more sophisticated applications.
 
-1. link:Building_a_Simple_Engine/introduction.adoc[*Building a Simple Game Engine*] - Ready to take your Vulkan skills to the next level?
+1. xref:Building_a_Simple_Engine/introduction.adoc[*Building a Simple Game Engine*] - Ready to take your Vulkan skills to the next level?
 This tutorial series will teach you how to structure your Vulkan code into a reusable and maintainable engine architecture.
 You'll learn engine architecture and design patterns, scene management with hierarchical object systems, camera systems and controls, efficient resource and memory management, Entity Component System (ECS) patterns, render system abstraction, input handling, and robust game loop design with proper timing.
 The series also covers essential math and rendering concepts needed for advanced techniques like Forward+ rendering with tiled lighting, shadow mapping techniques, HRTF spatial audio integration, GPU-accelerated physics simulation using compute shaders, and Ray Query for hybrid rendering effects.
@@ -71,4 +71,4 @@ Don't hesitate to reach out to these communities - they're filled with developer
 Thank you for following along with this tutorial series. You've taken a big
 first step in a long journey.
 
-link:17_Multithreading.adoc[Previous: Multithreading] | link:Building_a_Simple_Engine/introduction.adoc[Next: Building a Simple Engine]
+xref:17_Multithreading.adoc[Previous: Multithreading] | xref:Building_a_Simple_Engine/introduction.adoc[Next: Building a Simple Engine]

--- a/en/courses/18_Ray_tracing/01_Dynamic_rendering.adoc
+++ b/en/courses/18_Ray_tracing/01_Dynamic_rendering.adoc
@@ -81,7 +81,7 @@ vk::RenderingInfo renderingInfo = {
 commandBuffers[frameIndex].beginRendering(renderingInfo);
 ----
 
-For more context, refer to the previous tutorial link:../../03_Drawing_a_triangle/02_Graphics_pipeline_basics/03_Render_passes.adoc[chapter].
+For more context, refer to the previous tutorial xref:../../03_Drawing_a_triangle/02_Graphics_pipeline_basics/03_Render_passes.adoc[chapter].
 
 === Dynamic rendering with RenderDoc
 


### PR DESCRIPTION
Hello! So, I was reading specifically [Loading Models](https://docs.vulkan.org/tutorial/latest/08_Loading_models.html) and stumbled upon a 404 clicking the link [Development Environment](https://docs.vulkan.org/tutorial/latest/02_Development_environment.adoc) on that page. The '.adoc' is not converted to '.html' because it uses 'link:' (should be used for external links) instead of 'xref:' (internal doc links). So I wanted to fix that but ended up doing a little regex (`link:.*\.adoc`) to fix everywhere that's the case (and I checked, they do currently 404 on docs.vulkan.org/tutorial/latest).