### PR TITLE
Fix variable name typo in 01_Command_buffers.adoc

### DIFF
--- a/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.adoc
+++ b/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.adoc
@@ -200,7 +200,7 @@ void transition_image_layout(
 		    .dependencyFlags         = {},
 		    .imageMemoryBarrierCount = 1,
 		    .pImageMemoryBarriers    = &barrier};
-    commandBuffer.pipelineBarrier2(dependencyInfo);
+    commandBuffer.pipelineBarrier2(dependency_info);
 }
 ----
 


### PR DESCRIPTION
Fixed an inconsistency within the `transition_image_layout()` function where `dependency_info` was incorrectly written in camelCase, not snake_case like in later C++ source files.

Please note that the `attachments/14_command_buffers.cpp` file linked at the bottom of `01_Command_buffers.adoc` includes no mention of the `transition_image_layout()` function, which is potentially a mistake, but this has not been addressed in this PR. I'd be happy to open a separate issue for this if necessary.