### PR TITLE
Update overview

### DIFF
--- a/en/01_Overview.adoc
+++ b/en/01_Overview.adoc
@@ -130,14 +130,13 @@ Some platforms allow you to render directly to a display without interacting
 These allow you to create a surface that represents the entire screen and
 could be used to implement your own window manager, for example.
 
-=== Step 4 - Image views and Dynamic Rendering
+=== Step 4 - Swap chain image views
 
 To draw to an image acquired from the swap chain, we would typically wrap
-it into a `vk::ImageView` and `vk::Framebuffer`. An image view references a specific
-part of an image to be used, and a framebuffer references image views that are
-to be used for color, depth, and stencil targets.
-Because there could be many different images in the swap chain,
-we would preemptively create an image view and framebuffer for each
+it into a `vk::ImageView`. An image view references a specific
+part of an image to be used for e.g. color writes.
+Because there could be different images in the swap chain,
+we would preemptively create an image view for each
 of them and select the right one at draw time.
 
 === Step 5 - Dynamic Rendering Overview


### PR DESCRIPTION
This updates the overview chapter, removing the mention of framebuffers for swap chain images. These are no longer used with dynamic rendering.