### PR TITLE
Reorder navigation topics and mention advanced chapters

### DIFF
--- a/antora/modules/ROOT/nav.adoc
+++ b/antora/modules/ROOT/nav.adoc
@@ -62,8 +62,6 @@
 ** xref:courses/18_Ray_tracing/06_Reflections.adoc[Reflections]
 ** xref:courses/18_Ray_tracing/07_Conclusion.adoc[Conclusion]
 * xref:courses/siggraph2026_vk_tutorial/00_Overview.adoc[How to write a Vulkan application in 2026]
-* xref:90_FAQ.adoc[FAQ]
-* link:https://github.com/KhronosGroup/Vulkan-Tutorial[GitHub Repository, window=_blank]
 
 * Building a Simple Engine
 ** xref:Building_a_Simple_Engine/introduction.adoc[Introduction]
@@ -219,6 +217,103 @@
 *** xref:Advanced_Vulkan_Compute/12_Mobile_and_Embedded_Compute/04_embedded_beyond_mobile.adoc[Beyond Mobile: Embedded and Headless Compute]
 ** xref:Advanced_Vulkan_Compute/conclusion.adoc[Conclusion]
 
+* Synchronization 2
+** xref:Synchronization/introduction.adoc[Introduction]
+** Anatomy of a Dependency
+*** xref:Synchronization/Anatomy_of_a_Dependency/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Anatomy_of_a_Dependency/02_execution_vs_memory.adoc[Execution vs. Memory]
+*** xref:Synchronization/Anatomy_of_a_Dependency/03_sync2_advantage.adoc[Sync 2 Advantage]
+*** xref:Synchronization/Anatomy_of_a_Dependency/04_refined_pipeline_stages.adoc[Refined Pipeline Stages]
+*** xref:Synchronization/Anatomy_of_a_Dependency/05_conclusion.adoc[Conclusion]
+** Pipeline Barriers and Transitions
+*** xref:Synchronization/Pipeline_Barriers_Transitions/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Pipeline_Barriers_Transitions/02_image_barrier.adoc[The Image Barrier]
+*** xref:Synchronization/Pipeline_Barriers_Transitions/03_queue_family_ownership.adoc[Queue Family Ownership]
+*** xref:Synchronization/Pipeline_Barriers_Transitions/04_global_vs_local_barriers.adoc[Global vs. Local Barriers]
+** Timeline Semaphores
+*** xref:Synchronization/Timeline_Semaphores/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Timeline_Semaphores/02_unifying_sync.adoc[Unifying Sync]
+*** xref:Synchronization/Timeline_Semaphores/03_monotonic_counter.adoc[Monotonic Counter]
+*** xref:Synchronization/Timeline_Semaphores/04_wait_before_signal.adoc[Wait Before Signal]
+** Frame-in-Flight Architecture
+*** xref:Synchronization/Frame_in_Flight/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Frame_in_Flight/02_managing_concurrent_frames.adoc[Managing Concurrent Frames]
+*** xref:Synchronization/Frame_in_Flight/03_resource_lifetimes.adoc[Resource Lifetimes]
+** Asynchronous Compute & Overlap
+*** xref:Synchronization/Async_Compute_Overlap/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Async_Compute_Overlap/02_maximizing_throughput.adoc[Maximizing Throughput]
+*** xref:Synchronization/Async_Compute_Overlap/03_async_post_processing.adoc[Async Post-processing]
+*** xref:Synchronization/Async_Compute_Overlap/04_bubble_problem.adoc[The Bubble Problem]
+** Transfer Queues & Asset Streaming Sync
+*** xref:Synchronization/Transfer_Queues_Streaming/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Transfer_Queues_Streaming/02_non_blocking_uploads.adoc[Non-blocking Uploads]
+*** xref:Synchronization/Transfer_Queues_Streaming/03_staging_sync.adoc[Staging Sync]
+** Synchronization in Dynamic Rendering
+*** xref:Synchronization/Dynamic_Rendering_Sync/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Dynamic_Rendering_Sync/02_subpass_replacement.adoc[Subpass Replacement]
+*** xref:Synchronization/Dynamic_Rendering_Sync/03_local_read_sync.adoc[Local Read Sync]
+** Host Image Copies & Memory Mapped Sync
+*** xref:Synchronization/Host_Image_Copies_Memory_Sync/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Host_Image_Copies_Memory_Sync/02_cpu_to_image_access.adoc[CPU-to-Image Access]
+*** xref:Synchronization/Host_Image_Copies_Memory_Sync/03_visibility_flushes.adoc[Visibility Flushes]
+** Debugging with Synchronization Validation
+*** xref:Synchronization/Synchronization_Validation/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Synchronization_Validation/02_validation_layer.adoc[Validation Layer]
+*** xref:Synchronization/Synchronization_Validation/03_interpreting_vuids.adoc[Interpreting VUIDs]
+** Profiling, Batching, and Optimization
+*** xref:Synchronization/Profiling_Optimization/01_introduction.adoc[Introduction]
+*** xref:Synchronization/Profiling_Optimization/02_barrier_batching.adoc[Barrier Batching]
+*** xref:Synchronization/Profiling_Optimization/03_visualizing_stalls.adoc[Visualizing Stalls]
+
+* Advanced glTF: High-Performance Character Pipelines
+** xref:Advanced_glTF/introduction.adoc[Introduction]
+** Scene Graph & Transform Hierarchy
+*** xref:Advanced_glTF/Scene_Graph_Hierarchy/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Scene_Graph_Hierarchy/02_engine_expansion.adoc[Engine expansion]
+*** xref:Advanced_glTF/Scene_Graph_Hierarchy/03_physics_syncing.adoc[Physics syncing]
+*** xref:Advanced_glTF/Scene_Graph_Hierarchy/04_metadata_and_physics_extras.adoc[Metadata & physics extras]
+*** xref:Advanced_glTF/Scene_Graph_Hierarchy/05_conclusion.adoc[Conclusion]
+** Skeletal & Compute Skinning
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/02_skinning_math.adoc[The mathematics of skinning]
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/03_compute_skinning.adoc[The compute skinning pipeline]
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/04_shared_vertex_buffer.adoc[Skin once, use everywhere]
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/05_interpolation_blending.adoc[Interpolation & blending]
+*** xref:Advanced_glTF/Skeletal_Compute_Skinning/06_conclusion.adoc[Conclusion]
+** Physics Integration
+*** xref:Advanced_glTF/Physics_Integration/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Physics_Integration/02_bone_proxy_colliders.adoc[Bone proxy colliders]
+*** xref:Advanced_glTF/Physics_Integration/03_constraints_and_joint_limits.adoc[Constraints & joint limits]
+*** xref:Advanced_glTF/Physics_Integration/04_ragdoll_handoff.adoc[Ragdoll handoff]
+*** xref:Advanced_glTF/Physics_Integration/05_self_collision_filtering.adoc[Self-collision filtering]
+*** xref:Advanced_glTF/Physics_Integration/06_conclusion.adoc[Conclusion]
+** Procedural Animation & IK
+*** xref:Advanced_glTF/Procedural_Animation_IK/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Procedural_Animation_IK/02_ccd_ik.adoc[CCD IK]
+*** xref:Advanced_glTF/Procedural_Animation_IK/03_fabrik.adoc[FABRIK]
+*** xref:Advanced_glTF/Procedural_Animation_IK/04_foot_placement.adoc[Foot placement]
+*** xref:Advanced_glTF/Procedural_Animation_IK/05_look_at.adoc[Look-at]
+*** xref:Advanced_glTF/Procedural_Animation_IK/06_physics_driven_lean.adoc[Physics-driven lean]
+*** xref:Advanced_glTF/Procedural_Animation_IK/07_conclusion.adoc[Conclusion]
+** Morph Targets & Facial Animation
+*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/02_shape_key_ingestion.adoc[Shape key ingestion]
+*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/03_bindless_morph_buffers.adoc[Bindless morph buffers]
+*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/04_conclusion.adoc[Conclusion]
+** Tooling & Production Pipeline
+*** xref:Advanced_glTF/Tooling_Production_Pipeline/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Tooling_Production_Pipeline/02_blender_workflow.adoc[Blender workflow]
+*** xref:Advanced_glTF/Tooling_Production_Pipeline/03_validation.adoc[Validation]
+*** xref:Advanced_glTF/Tooling_Production_Pipeline/04_gltf_viewer_audit.adoc[glTF viewer audit]
+*** xref:Advanced_glTF/Tooling_Production_Pipeline/05_conclusion.adoc[Conclusion]
+** Debugging & Visual Auditing
+*** xref:Advanced_glTF/Debugging_Visual_Auditing/01_introduction.adoc[Introduction]
+*** xref:Advanced_glTF/Debugging_Visual_Auditing/02_debug_drawers.adoc[Debug drawers]
+*** xref:Advanced_glTF/Debugging_Visual_Auditing/03_skinning_heatmaps.adoc[Skinning heatmaps]
+*** xref:Advanced_glTF/Debugging_Visual_Auditing/04_renderdoc_analysis.adoc[RenderDoc analysis]
+*** xref:Advanced_glTF/Debugging_Visual_Auditing/05_conclusion.adoc[Conclusion]
+** xref:Advanced_glTF/appendix_types.adoc[Appendix: Common Types Reference]
+
 * Machine Learning Inference
 ** xref:ML_Inference/introduction.adoc[Introduction]
 ** ML Inference Pipeline
@@ -294,55 +389,6 @@
 *** xref:ML_Inference/Embedded_Applications/08_nnef_example.adoc[NNEF on Embedded: Example]
 *** xref:ML_Inference/Embedded_Applications/09_conclusion.adoc[Conclusion]
 ** xref:ML_Inference/glossary.adoc[Glossary]
-
-* Advanced glTF: High-Performance Character Pipelines
-** xref:Advanced_glTF/introduction.adoc[Introduction]
-** Scene Graph & Transform Hierarchy
-*** xref:Advanced_glTF/Scene_Graph_Hierarchy/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Scene_Graph_Hierarchy/02_engine_expansion.adoc[Engine expansion]
-*** xref:Advanced_glTF/Scene_Graph_Hierarchy/03_physics_syncing.adoc[Physics syncing]
-*** xref:Advanced_glTF/Scene_Graph_Hierarchy/04_metadata_and_physics_extras.adoc[Metadata & physics extras]
-*** xref:Advanced_glTF/Scene_Graph_Hierarchy/05_conclusion.adoc[Conclusion]
-** Skeletal & Compute Skinning
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/02_skinning_math.adoc[The mathematics of skinning]
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/03_compute_skinning.adoc[The compute skinning pipeline]
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/04_shared_vertex_buffer.adoc[Skin once, use everywhere]
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/05_interpolation_blending.adoc[Interpolation & blending]
-*** xref:Advanced_glTF/Skeletal_Compute_Skinning/06_conclusion.adoc[Conclusion]
-** Physics Integration
-*** xref:Advanced_glTF/Physics_Integration/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Physics_Integration/02_bone_proxy_colliders.adoc[Bone proxy colliders]
-*** xref:Advanced_glTF/Physics_Integration/03_constraints_and_joint_limits.adoc[Constraints & joint limits]
-*** xref:Advanced_glTF/Physics_Integration/04_ragdoll_handoff.adoc[Ragdoll handoff]
-*** xref:Advanced_glTF/Physics_Integration/05_self_collision_filtering.adoc[Self-collision filtering]
-*** xref:Advanced_glTF/Physics_Integration/06_conclusion.adoc[Conclusion]
-** Procedural Animation & IK
-*** xref:Advanced_glTF/Procedural_Animation_IK/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Procedural_Animation_IK/02_ccd_ik.adoc[CCD IK]
-*** xref:Advanced_glTF/Procedural_Animation_IK/03_fabrik.adoc[FABRIK]
-*** xref:Advanced_glTF/Procedural_Animation_IK/04_foot_placement.adoc[Foot placement]
-*** xref:Advanced_glTF/Procedural_Animation_IK/05_look_at.adoc[Look-at]
-*** xref:Advanced_glTF/Procedural_Animation_IK/06_physics_driven_lean.adoc[Physics-driven lean]
-*** xref:Advanced_glTF/Procedural_Animation_IK/07_conclusion.adoc[Conclusion]
-** Morph Targets & Facial Animation
-*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/02_shape_key_ingestion.adoc[Shape key ingestion]
-*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/03_bindless_morph_buffers.adoc[Bindless morph buffers]
-*** xref:Advanced_glTF/Morph_Targets_Facial_Animation/04_conclusion.adoc[Conclusion]
-** Tooling & Production Pipeline
-*** xref:Advanced_glTF/Tooling_Production_Pipeline/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Tooling_Production_Pipeline/02_blender_workflow.adoc[Blender workflow]
-*** xref:Advanced_glTF/Tooling_Production_Pipeline/03_validation.adoc[Validation]
-*** xref:Advanced_glTF/Tooling_Production_Pipeline/04_gltf_viewer_audit.adoc[glTF viewer audit]
-*** xref:Advanced_glTF/Tooling_Production_Pipeline/05_conclusion.adoc[Conclusion]
-** Debugging & Visual Auditing
-*** xref:Advanced_glTF/Debugging_Visual_Auditing/01_introduction.adoc[Introduction]
-*** xref:Advanced_glTF/Debugging_Visual_Auditing/02_debug_drawers.adoc[Debug drawers]
-*** xref:Advanced_glTF/Debugging_Visual_Auditing/03_skinning_heatmaps.adoc[Skinning heatmaps]
-*** xref:Advanced_glTF/Debugging_Visual_Auditing/04_renderdoc_analysis.adoc[RenderDoc analysis]
-*** xref:Advanced_glTF/Debugging_Visual_Auditing/05_conclusion.adoc[Conclusion]
-** xref:Advanced_glTF/appendix_types.adoc[Appendix: Common Types Reference]
 
 * OpenXR and Vulkan 1.3 Spatial Computing
 ** xref:OpenXR_Vulkan_Spatial_Computing/introduction.adoc[Introduction]
@@ -444,50 +490,6 @@
 *** xref:OpenXR_Vulkan_Spatial_Computing/20_Spatial_Diagnostics_CI_CD/03_automated_qa.adoc[Automated QA]
 *** xref:OpenXR_Vulkan_Spatial_Computing/20_Spatial_Diagnostics_CI_CD/04_incorporating_into_the_engine.adoc[Incorporating into the Engine]
 ** xref:OpenXR_Vulkan_Spatial_Computing/conclusion.adoc[Conclusion]
-* Synchronization 2
-** xref:Synchronization/introduction.adoc[Introduction]
-** Anatomy of a Dependency
-*** xref:Synchronization/Anatomy_of_a_Dependency/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Anatomy_of_a_Dependency/02_execution_vs_memory.adoc[Execution vs. Memory]
-*** xref:Synchronization/Anatomy_of_a_Dependency/03_sync2_advantage.adoc[Sync 2 Advantage]
-*** xref:Synchronization/Anatomy_of_a_Dependency/04_refined_pipeline_stages.adoc[Refined Pipeline Stages]
-*** xref:Synchronization/Anatomy_of_a_Dependency/05_conclusion.adoc[Conclusion]
-** Pipeline Barriers and Transitions
-*** xref:Synchronization/Pipeline_Barriers_Transitions/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Pipeline_Barriers_Transitions/02_image_barrier.adoc[The Image Barrier]
-*** xref:Synchronization/Pipeline_Barriers_Transitions/03_queue_family_ownership.adoc[Queue Family Ownership]
-*** xref:Synchronization/Pipeline_Barriers_Transitions/04_global_vs_local_barriers.adoc[Global vs. Local Barriers]
-** Timeline Semaphores
-*** xref:Synchronization/Timeline_Semaphores/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Timeline_Semaphores/02_unifying_sync.adoc[Unifying Sync]
-*** xref:Synchronization/Timeline_Semaphores/03_monotonic_counter.adoc[Monotonic Counter]
-*** xref:Synchronization/Timeline_Semaphores/04_wait_before_signal.adoc[Wait Before Signal]
-** Frame-in-Flight Architecture
-*** xref:Synchronization/Frame_in_Flight/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Frame_in_Flight/02_managing_concurrent_frames.adoc[Managing Concurrent Frames]
-*** xref:Synchronization/Frame_in_Flight/03_resource_lifetimes.adoc[Resource Lifetimes]
-** Asynchronous Compute & Overlap
-*** xref:Synchronization/Async_Compute_Overlap/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Async_Compute_Overlap/02_maximizing_throughput.adoc[Maximizing Throughput]
-*** xref:Synchronization/Async_Compute_Overlap/03_async_post_processing.adoc[Async Post-processing]
-*** xref:Synchronization/Async_Compute_Overlap/04_bubble_problem.adoc[The Bubble Problem]
-** Transfer Queues & Asset Streaming Sync
-*** xref:Synchronization/Transfer_Queues_Streaming/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Transfer_Queues_Streaming/02_non_blocking_uploads.adoc[Non-blocking Uploads]
-*** xref:Synchronization/Transfer_Queues_Streaming/03_staging_sync.adoc[Staging Sync]
-** Synchronization in Dynamic Rendering
-*** xref:Synchronization/Dynamic_Rendering_Sync/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Dynamic_Rendering_Sync/02_subpass_replacement.adoc[Subpass Replacement]
-*** xref:Synchronization/Dynamic_Rendering_Sync/03_local_read_sync.adoc[Local Read Sync]
-** Host Image Copies & Memory Mapped Sync
-*** xref:Synchronization/Host_Image_Copies_Memory_Sync/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Host_Image_Copies_Memory_Sync/02_cpu_to_image_access.adoc[CPU-to-Image Access]
-*** xref:Synchronization/Host_Image_Copies_Memory_Sync/03_visibility_flushes.adoc[Visibility Flushes]
-** Debugging with Synchronization Validation
-*** xref:Synchronization/Synchronization_Validation/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Synchronization_Validation/02_validation_layer.adoc[Validation Layer]
-*** xref:Synchronization/Synchronization_Validation/03_interpreting_vuids.adoc[Interpreting VUIDs]
-** Profiling, Batching, and Optimization
-*** xref:Synchronization/Profiling_Optimization/01_introduction.adoc[Introduction]
-*** xref:Synchronization/Profiling_Optimization/02_barrier_batching.adoc[Barrier Batching]
-*** xref:Synchronization/Profiling_Optimization/03_visualizing_stalls.adoc[Visualizing Stalls]
+
+* xref:90_FAQ.adoc[FAQ]
+* link:https://github.com/KhronosGroup/Vulkan-Tutorial[GitHub Repository, window=_blank]

--- a/en/00_Introduction.adoc
+++ b/en/00_Introduction.adoc
@@ -184,6 +184,7 @@ In addition to the basic tutorial teaching how to use Vulkan, there are dedicate
 
 * xref:courses/18_Ray_tracing/00_Overview.adoc[Ray Tracing]
 * xref:Building_a_Simple_Engine/introduction.adoc[Building a simple game engine]
+* xref:Building_a_Simple_Engine/Courses/Opacity_Micromaps/00_introduction.adoc[Opacity Micromaps]
 * xref:Advanced_Vulkan_Compute/introduction.adoc[Advanced compute techniques]
 * xref:Synchronization/introduction.adoc[Using new synchronization features]
 * xref:Advanced_glTF/introduction.adoc[Advanced glTF]

--- a/en/00_Introduction.adoc
+++ b/en/00_Introduction.adoc
@@ -190,4 +190,4 @@ In addition to the basic tutorial teaching how to use Vulkan, there are dedicate
 * xref:Advanced_glTF/introduction.adoc[Advanced glTF]
 * xref:ML_Inference/introduction.adoc[Machine learning inference]
 * xref:OpenXR_Vulkan_Spatial_Computing/introduction.adoc[OpenXR]
-
+* xref:AI_Assisted_Vulkan/introduction.adoc[AI-Assisted Vulkan Development]

--- a/en/00_Introduction.adoc
+++ b/en/00_Introduction.adoc
@@ -177,3 +177,16 @@ https://github.com/KhronosGroup/Vulkan-Tutorial[GitHub repository].
 
 Ready to dive into the future of high performance graphics APIs?
 xref:01_Overview.adoc[Let's go!]
+
+== Advanced topics
+
+In addition to the basic tutorial teaching how to use Vulkan, there are dedicated chapters for advanced topics that you can dive into once you've learned the basics:
+
+* xref:courses/18_Ray_tracing/00_Overview.adoc[Ray Tracing]
+* xref:Building_a_Simple_Engine/introduction.adoc[Building a simple game engine]
+* xref:Advanced_Vulkan_Compute/introduction.adoc[Advanced compute techniques]
+* xref:Synchronization/introduction.adoc[Using new synchronization features]
+* xref:Advanced_glTF/introduction.adoc[Advanced glTF]
+* xref:ML_Inference/introduction.adoc[Machine learning inference]
+* xref:OpenXR_Vulkan_Spatial_Computing/introduction.adoc[OpenXR]
+


### PR DESCRIPTION
With the recent merges of new chapters, ordering in the navigation felt a bit off. This PR adjusts the navigation, does some minor reordering and puts the FAQ and repo link at the bottom again.

It also adds a list of advanced topic to the tutorial's index page, so people are aware those exists.