### PR TITLE
Remove all parts of the KHR_vulkan_enable extensions.  

### DIFF
--- a/attachments/openxr_engine/renderer_core.cpp
+++ b/attachments/openxr_engine/renderer_core.cpp
@@ -613,12 +613,6 @@ bool Renderer::createInstance(const std::string& appName, bool enableValidationL
       extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     }
 
-    // NEW: Add OpenXR mandatory extensions
-    if (xrMode) {
-      auto xrExtensions = xrContext.getVulkanInstanceExtensions();
-      extensions.insert(extensions.end(), xrExtensions.begin(), xrExtensions.end());
-    }
-
     // Create instance info
     vk::InstanceCreateInfo createInfo{
       .pApplicationInfo = &appInfo,
@@ -892,16 +886,6 @@ void Renderer::addSupportedOptionalExtensions() {
       }
     }
 
-    // NEW: Add OpenXR mandatory device extensions
-    if (xrMode) {
-      auto xrDevExtensions = xrContext.getVulkanDeviceExtensions(*physicalDevice);
-      for (const auto& ext : xrDevExtensions) {
-        // Ensure we don't duplicate
-        if (std::find(deviceExtensions.begin(), deviceExtensions.end(), std::string(ext)) == deviceExtensions.end()) {
-          deviceExtensions.push_back(ext);
-        }
-      }
-    }
   } catch (const std::exception& e) {
     std::cerr << "Warning: Failed to add optional extensions: " << e.what() << std::endl;
   }

--- a/attachments/openxr_engine/xr_context.cpp
+++ b/attachments/openxr_engine/xr_context.cpp
@@ -105,11 +105,7 @@ bool XrContext::createInstance(const std::string& appName) {
     }
 
     // Load Vulkan extension functions
-    xrGetInstanceProcAddr(instance, "xrGetVulkanInstanceExtensionsKHR", (PFN_xrVoidFunction*)&pfnGetVulkanInstanceExtensionsKHR);
-    xrGetInstanceProcAddr(instance, "xrGetVulkanDeviceExtensionsKHR", (PFN_xrVoidFunction*)&pfnGetVulkanDeviceExtensionsKHR);
-    xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsRequirementsKHR", (PFN_xrVoidFunction*)&pfnGetVulkanGraphicsRequirementsKHR);
     xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsRequirements2KHR", (PFN_xrVoidFunction*)&pfnGetVulkanGraphicsRequirements2KHR);
-    xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsDeviceKHR", (PFN_xrVoidFunction*)&pfnGetVulkanGraphicsDeviceKHR);
     xrGetInstanceProcAddr(instance, "xrGetVulkanGraphicsDevice2KHR", (PFN_xrVoidFunction*)&pfnGetVulkanGraphicsDevice2KHR);
 
     XrSystemGetInfo systemGetInfo{XR_TYPE_SYSTEM_GET_INFO};
@@ -306,56 +302,12 @@ void XrContext::cleanup() {
     }
 }
 
-std::vector<const char*> XrContext::getVulkanInstanceExtensions() {
-    if (instance == XR_NULL_HANDLE) return { "XR_KHR_vulkan_enable2" };
-    uint32_t size = 0;
-    if (!pfnGetVulkanInstanceExtensionsKHR) return {};
-    pfnGetVulkanInstanceExtensionsKHR(instance, systemId, 0, &size, nullptr);
-    std::vector<char> buffer(size);
-    pfnGetVulkanInstanceExtensionsKHR(instance, systemId, size, &size, buffer.data());
-    
-    static std::vector<std::string> extStrings;
-    extStrings.clear();
-    std::string extensions(buffer.data());
-    std::istringstream iss(extensions);
-    std::string ext;
-    while (iss >> ext) extStrings.push_back(ext);
-
-    static std::vector<const char*> extPtrs;
-    extPtrs.clear();
-    for (const auto& s : extStrings) extPtrs.push_back(s.c_str());
-    return extPtrs;
-}
-
-std::vector<const char*> XrContext::getVulkanDeviceExtensions(vk::PhysicalDevice physicalDevice) {
-    if (instance == XR_NULL_HANDLE) return { "VK_KHR_external_memory", "VK_KHR_external_semaphore" };
-    uint32_t size = 0;
-    if (!pfnGetVulkanDeviceExtensionsKHR) return {};
-    pfnGetVulkanDeviceExtensionsKHR(instance, systemId, 0, &size, nullptr);
-    std::vector<char> buffer(size);
-    pfnGetVulkanDeviceExtensionsKHR(instance, systemId, size, &size, buffer.data());
-
-    static std::vector<std::string> devExtStrings;
-    devExtStrings.clear();
-    std::string extensions(buffer.data());
-    std::istringstream iss(extensions);
-    std::string ext;
-    while (iss >> ext) devExtStrings.push_back(ext);
-
-    static std::vector<const char*> devExtPtrs;
-    devExtPtrs.clear();
-    for (const auto& s : devExtStrings) devExtPtrs.push_back(s.c_str());
-    return devExtPtrs;
-}
-
 const uint8_t* XrContext::getRequiredLUID() {
     if (!luidValid && vkInstance && instance != XR_NULL_HANDLE && systemId != XR_NULL_SYSTEM_ID) {
         // Step 1: Call graphics requirements as mandated by spec before getting graphics device
         XrGraphicsRequirementsVulkanKHR graphicsRequirements{XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR};
         if (pfnGetVulkanGraphicsRequirements2KHR) {
             pfnGetVulkanGraphicsRequirements2KHR(instance, systemId, &graphicsRequirements);
-        } else if (pfnGetVulkanGraphicsRequirementsKHR) {
-            pfnGetVulkanGraphicsRequirementsKHR(instance, systemId, &graphicsRequirements);
         }
 
         // Step 2: Get the physical device from OpenXR
@@ -367,8 +319,6 @@ const uint8_t* XrContext::getRequiredLUID() {
             getInfo.systemId = systemId;
             getInfo.vulkanInstance = (VkInstance)vkInstance;
             result = pfnGetVulkanGraphicsDevice2KHR(instance, &getInfo, &vkPhysicalDevice);
-        } else if (pfnGetVulkanGraphicsDeviceKHR) {
-            result = pfnGetVulkanGraphicsDeviceKHR(instance, systemId, (VkInstance)vkInstance, &vkPhysicalDevice);
         }
 
         if (result == XR_SUCCESS && vkPhysicalDevice != VK_NULL_HANDLE) {

--- a/attachments/openxr_engine/xr_context.h
+++ b/attachments/openxr_engine/xr_context.h
@@ -48,8 +48,6 @@ public:
 #endif
 
     // Core Handshake (Chapter 2)
-    std::vector<const char*> getVulkanInstanceExtensions();
-    std::vector<const char*> getVulkanDeviceExtensions(vk::PhysicalDevice physicalDevice);
     const uint8_t* getRequiredLUID();
 
     // Swapchain Management (Chapter 3 & 8)
@@ -118,11 +116,7 @@ public:
     static bool checkRuntimeAvailable();
 
 private:
-    PFN_xrGetVulkanInstanceExtensionsKHR pfnGetVulkanInstanceExtensionsKHR = nullptr;
-    PFN_xrGetVulkanDeviceExtensionsKHR pfnGetVulkanDeviceExtensionsKHR = nullptr;
-    PFN_xrGetVulkanGraphicsRequirementsKHR pfnGetVulkanGraphicsRequirementsKHR = nullptr;
     PFN_xrGetVulkanGraphicsRequirements2KHR pfnGetVulkanGraphicsRequirements2KHR = nullptr;
-    PFN_xrGetVulkanGraphicsDeviceKHR pfnGetVulkanGraphicsDeviceKHR = nullptr;
     PFN_xrGetVulkanGraphicsDevice2KHR pfnGetVulkanGraphicsDevice2KHR = nullptr;
 
     XrInstance instance;


### PR DESCRIPTION
They weren't technically being used as we do ONLY use KHR_vulkan_enable2, but they were loading the older extensions which is not necessary.