### PR TITLE
Add a single comma for grammatical correctness

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.adoc
@@ -4,7 +4,7 @@
 
 Unlike earlier APIs, shader code in Vulkan has to be specified in a bytecode
 format as opposed to human-readable syntax like
-https://en.wikipedia.org/wiki/OpenGL_Shading_Language[GLSL]
+https://en.wikipedia.org/wiki/OpenGL_Shading_Language[GLSL],
 https://shader-slang.org/slang/user-guide/[Slang], and
 https://en.wikipedia.org/wiki/High-Level_Shading_Language[HLSL].
 This bytecode format is called https://www.khronos.org/spir[SPIR-V] and is designed


### PR DESCRIPTION
I know, so helpful, right? There was a missing comma between "GLSL" and "Slang" and it was really bugging me. Original text: 

> Unlike earlier APIs, shader code in Vulkan has to be specified in a bytecode format as opposed to human-readable syntax like [GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language) [Slang](https://shader-slang.org/slang/user-guide/), and [HLSL](https://en.wikipedia.org/wiki/High-Level_Shading_Language).