### PR TITLE
Fix depth-stencil image aspect masks

### DIFF
--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
+#include <vulkan/vulkan_format_traits.hpp>
 
 #if defined(__INTELLISENSE__) || !defined(USE_CPP20_MODULES)
 #	include <vulkan/vulkan_raii.hpp>
@@ -813,7 +814,7 @@ class HelloTriangleApplication
 	{
 		vk::Format depthFormat = findDepthFormat();
 		depthImageAspect       = vk::ImageAspectFlagBits::eDepth;
-		if (hasStencilComponent(depthFormat))
+		if (vk::hasStencilComponent(depthFormat))
 		{
 			depthImageAspect |= vk::ImageAspectFlagBits::eStencil;
 		}
@@ -847,11 +848,6 @@ class HelloTriangleApplication
 		    {vk::Format::eD32Sfloat, vk::Format::eD32SfloatS8Uint, vk::Format::eD24UnormS8Uint},
 		    vk::ImageTiling::eOptimal,
 		    vk::FormatFeatureFlagBits::eDepthStencilAttachment);
-	}
-
-	static bool hasStencilComponent(vk::Format format)
-	{
-		return format == vk::Format::eD32SfloatS8Uint || format == vk::Format::eD24UnormS8Uint;
 	}
 
 	void createTextureImage()

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -137,6 +137,7 @@ class HelloTriangleApplication
 	vk::raii::Image        depthImage       = nullptr;
 	vk::raii::DeviceMemory depthImageMemory = nullptr;
 	vk::raii::ImageView    depthImageView   = nullptr;
+	vk::ImageAspectFlags   depthImageAspect = vk::ImageAspectFlagBits::eDepth;
 
 	uint32_t               mipLevels          = 0;
 	vk::raii::Image        textureImage       = nullptr;
@@ -811,9 +812,14 @@ class HelloTriangleApplication
 	void createDepthResources()
 	{
 		vk::Format depthFormat = findDepthFormat();
+		depthImageAspect       = vk::ImageAspectFlagBits::eDepth;
+		if (hasStencilComponent(depthFormat))
+		{
+			depthImageAspect |= vk::ImageAspectFlagBits::eStencil;
+		}
 
 		createImage(swapChainExtent.width, swapChainExtent.height, 1, msaaSamples, depthFormat, vk::ImageTiling::eOptimal, vk::ImageUsageFlagBits::eDepthStencilAttachment, vk::MemoryPropertyFlagBits::eDeviceLocal, depthImage, depthImageMemory);
-		depthImageView = createImageView(depthImage, depthFormat, vk::ImageAspectFlagBits::eDepth, 1);
+		depthImageView = createImageView(depthImage, depthFormat, depthImageAspect, 1);
 	}
 
 	vk::Format findSupportedFormat(const std::vector<vk::Format> &candidates, vk::ImageTiling tiling, vk::FormatFeatureFlags features) const
@@ -1376,7 +1382,7 @@ class HelloTriangleApplication
 				    .oldLayout        = vk::ImageLayout::eUndefined,
 				    .newLayout        = vk::ImageLayout::eDepthStencilAttachmentOptimal,
 				    .image            = *depthImage,
-				    .subresourceRange = {vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1}};
+				    .subresourceRange = {depthImageAspect, 0, 1, 0, 1}};
 
 				vk::ImageMemoryBarrier2 swapchainBarrier{
 				    .srcStageMask     = vk::PipelineStageFlagBits2::eColorAttachmentOutput,
@@ -1416,7 +1422,7 @@ class HelloTriangleApplication
 				    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
 				    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
 				    .image               = *depthImage,
-				    .subresourceRange    = {vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1}};
+				    .subresourceRange    = {depthImageAspect, 0, 1, 0, 1}};
 
 				vk::ImageMemoryBarrier swapchainBarrier{
 				    .srcAccessMask       = vk::AccessFlagBits::eNone,


### PR DESCRIPTION
## Summary
- derive the depth image aspect mask from the selected depth format
- use the mask for the image view and both layout-transition barriers

## Root cause
The tutorial can select a depth/stencil format such as VK_FORMAT_D32_SFLOAT_S8_UINT, while the attachment sample hardcodes VK_IMAGE_ASPECT_DEPTH_BIT. Validation then reports VUID-VkImageMemoryBarrier2-image-03320 because the stencil aspect is omitted.

## Validation
- Reproduced on macOS Apple Silicon (M2 Pro) with the Khronos validation layer.
- `cmake -S attachments -B build/tutorial -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=arm64 -DENABLE_CPP20_MODULE=OFF -DKTX_INCLUDE_DIR=... -DKTX_LIBRARY=...`
- `cmake --build build/tutorial --target 32_ecosystem_utilities -j4`
- standalone C++20 syntax check passed with Vulkan-Hpp defines
- `git diff --check` passed

The executable initializes Vulkan but exits in this checkout because the required tutorial asset file is not found from the build layout.