### PR TITLE
Add subresourceRange to blit barrier

### DIFF
--- a/en/09_Generating_Mipmaps.adoc
+++ b/en/09_Generating_Mipmaps.adoc
@@ -199,6 +199,7 @@ void generateMipmaps(vk::raii::CommandBuffer &commandBuffer,
 		                                  .srcQueueFamilyIndex = vk::QueueFamilyIgnored,
 		                                  .dstQueueFamilyIndex = vk::QueueFamilyIgnored,
 		                                  .image               = image,
+										  .subresourceRange    = {.aspectMask = vk::ImageAspectFlagBits::eColor, .levelCount = 1, .layerCount = 1}};
 }
 ----
 


### PR DESCRIPTION
To match the source since it wasn't included in the main guide but is necessary for it to function