### PR TITLE
Fix vk::raii::CreateImageView typo in the Image views chapter

### DIFF
--- a/en/03_Drawing_a_triangle/01_Presentation/02_Image_views.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/02_Image_views.adoc
@@ -119,7 +119,7 @@ for (auto &image : swapChainImages)
 }
 ----
 
-Creating the image view is now a matter of using the constructor of `vk::raii::CreateImageView`,
+Creating the image view is now a matter of using the constructor of `vk::raii::ImageView`,
 here via `std::vector::emplace_back`:
 
 [,c++]


### PR DESCRIPTION
There is no such type; the code right below it constructs a `vk::raii::ImageView`.