### PR TITLE
Explain why <map> is needed before the multimap example

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.adoc
@@ -111,8 +111,10 @@ bool isDeviceSuitable(vk::raii::PhysicalDevice const & physicalDevice)
 Instead of just checking if a device is suitable or not and going with the first
 one, you could also give each device a score and pick the highest one. That way
 you could favor a dedicated graphics card by giving it a higher score, but fall
-back to an integrated GPU if that's the only available one. You could implement
-something like that as follows:
+back to an integrated GPU if that's the only available one. This needs a
+`std::multimap` to keep the candidates sorted by score as we go, so that means a
+new header at the top of the file. You could implement something like that as
+follows:
 
 [,c++]
 ----


### PR DESCRIPTION
## Summary
- Physical_devices_and_queue_families.adoc introduces a `std::multimap`-based scoring example without explaining why a new `#include <map>` shows up at the top of the code block; adds a sentence connecting the two.

Closes #105