### PR TITLE
Make projection matrix members mutable

### DIFF
--- a/en/Building_a_Simple_Engine/Engine_Architecture/03_component_systems.adoc
+++ b/en/Building_a_Simple_Engine/Engine_Architecture/03_component_systems.adoc
@@ -226,8 +226,11 @@ private:
     float farPlane = 1000.0f;
 
     glm::mat4 viewMatrix = glm::mat4(1.0f);
-    glm::mat4 projectionMatrix = glm::mat4(1.0f);
-    bool projectionDirty = true;
+    // mutable: GetProjectionMatrix() is logically const (it just returns a
+    // matrix) even though it lazily recomputes and caches that matrix on
+    // first access after the projection parameters change.
+    mutable glm::mat4 projectionMatrix = glm::mat4(1.0f);
+    mutable bool projectionDirty = true;
 
 public:
     void SetPerspective(float fov, float aspect, float near, float far) {


### PR DESCRIPTION
`GetProjectionMatrix() const` assigned to `projectionMatrix`/`projectionDirty`, which won't compile. Marking those members `mutable` fixes it while keeping the getter correctly `const`, instead of dropping `const` from the method.

Fixes #370.