### PR TITLE
Exclude pipeline diagram from dark-mode SVG inversion

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/00_Introduction.adoc
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/00_Introduction.adoc
@@ -8,7 +8,7 @@ sequence of operations that take the vertices and textures of your meshes all
 the way to the pixels in the render targets. A simplified overview is displayed
 below:
 
-image::/images/vulkan_simplified_pipeline.svg[]
+image::/images/vulkan_simplified_pipeline.svg[role=no-invert]
 
 The *input assembler* collects the raw vertex data from the buffers you specify
 and may also use an index buffer to repeat certain elements without having to


### PR DESCRIPTION
The diagram's colors are described directly in the surrounding text (green = fixed-function, orange = programmable), but dark mode inverts all SVGs, flipping them. Adds `role=no-invert` so the diagram keeps its real colors in both themes.

Depends on KhronosGroup/Vulkan-Site#220.

Fixes #111.