### PR TITLE
Fix confusing swap chain image count calculation

### DIFF
--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.adoc
@@ -339,22 +339,16 @@ minimum number that it requires to function:
 
 [,c++]
 ----
-uint32_t imageCount = surfaceCapabilities.minImageCount;
+uint32_t minImageCount = surfaceCapabilities.minImageCount;
 ----
 
 However, simply sticking to this minimum means that we may sometimes have
 to wait on the driver to complete internal operations before we can acquire
-another image to render to. Therefore, it is recommended to request at least
-one more image than the minimum:
-
-[,c++]
-----
-uint32_t imageCount = surfaceCapabilities.minImageCount + 1;
-----
-
-We should also make sure to not exceed the maximum number of images while
-doing this, where `0` is a special value that means that there is no maximum,
-resulting in this helper function
+another image to render to. In practice, it's common to request a few more
+images than the strict minimum to give yourself some headroom - the helper
+function below requests at least three images, while also making sure to not
+exceed the maximum number of images the implementation supports, where `0` is
+a special value that means there is no maximum:
 
 [,c++]
 ----


### PR DESCRIPTION
The prose walked through an `imageCount = minImageCount + 1` example that didn't match what `chooseSwapMinImageCount` actually does (`std::max(3u, ...)`), and used a different variable name than the real function. Renames for consistency and rewrites the explanation to match the real logic.

Fixes #261.