### PR TITLE
Check presentation support in isDeviceSuitable

### DIFF
--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -166,9 +166,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -189,7 +197,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/05_window_surface.cpp
+++ b/attachments/05_window_surface.cpp
@@ -167,16 +167,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -175,16 +175,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/06_swap_chain_creation.cpp
+++ b/attachments/06_swap_chain_creation.cpp
@@ -174,9 +174,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -197,7 +205,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -176,16 +176,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/07_image_views.cpp
+++ b/attachments/07_image_views.cpp
@@ -175,9 +175,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -198,7 +206,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -177,16 +177,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/08_graphics_pipeline.cpp
+++ b/attachments/08_graphics_pipeline.cpp
@@ -176,9 +176,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -199,7 +207,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -178,16 +178,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/09_shader_modules.cpp
+++ b/attachments/09_shader_modules.cpp
@@ -177,9 +177,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -200,7 +208,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -179,9 +179,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -202,7 +210,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/10_fixed_functions.cpp
+++ b/attachments/10_fixed_functions.cpp
@@ -180,16 +180,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -180,9 +180,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -203,7 +211,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/12_graphics_pipeline_complete.cpp
+++ b/attachments/12_graphics_pipeline_complete.cpp
@@ -181,16 +181,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -185,9 +185,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -208,7 +216,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/14_command_buffers.cpp
+++ b/attachments/14_command_buffers.cpp
@@ -186,16 +186,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -193,9 +193,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -217,7 +225,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/15_hello_triangle.cpp
+++ b/attachments/15_hello_triangle.cpp
@@ -194,16 +194,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -196,9 +196,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -220,7 +228,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/16_frames_in_flight.cpp
+++ b/attachments/16_frames_in_flight.cpp
@@ -197,16 +197,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -230,16 +230,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/17_swap_chain_recreation.cpp
+++ b/attachments/17_swap_chain_recreation.cpp
@@ -229,9 +229,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -253,7 +261,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -257,9 +257,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -281,7 +289,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/19_vertex_buffer.cpp
+++ b/attachments/19_vertex_buffer.cpp
@@ -258,16 +258,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -257,9 +257,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -281,7 +289,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/20_staging_buffer.cpp
+++ b/attachments/20_staging_buffer.cpp
@@ -258,16 +258,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -264,9 +264,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -288,7 +296,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/21_index_buffer.cpp
+++ b/attachments/21_index_buffer.cpp
@@ -265,16 +265,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -283,16 +283,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/22_descriptor_layout.cpp
+++ b/attachments/22_descriptor_layout.cpp
@@ -282,9 +282,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -306,7 +314,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -287,9 +287,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -311,7 +319,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/23_descriptor_sets.cpp
+++ b/attachments/23_descriptor_sets.cpp
@@ -288,16 +288,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -295,16 +295,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/24_texture_image.cpp
+++ b/attachments/24_texture_image.cpp
@@ -294,9 +294,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -318,7 +326,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -298,9 +298,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -321,7 +329,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/25_sampler.cpp
+++ b/attachments/25_sampler.cpp
@@ -299,16 +299,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -300,16 +300,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/26_texture_mapping.cpp
+++ b/attachments/26_texture_mapping.cpp
@@ -299,9 +299,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -321,7 +329,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -315,16 +315,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/27_depth_buffering.cpp
+++ b/attachments/27_depth_buffering.cpp
@@ -314,9 +314,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -336,7 +344,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -321,9 +321,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -343,7 +351,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/28_model_loading.cpp
+++ b/attachments/28_model_loading.cpp
@@ -322,16 +322,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -323,16 +323,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/29_mipmapping.cpp
+++ b/attachments/29_mipmapping.cpp
@@ -322,9 +322,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -344,7 +352,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -329,9 +329,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -351,7 +359,7 @@ class HelloTriangleApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/30_multisampling.cpp
+++ b/attachments/30_multisampling.cpp
@@ -330,16 +330,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -298,16 +298,15 @@ class ComputeShaderApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/31_compute_shader.cpp
+++ b/attachments/31_compute_shader.cpp
@@ -297,9 +297,17 @@ class ComputeShaderApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -321,7 +329,7 @@ class ComputeShaderApplication
 		                                features.template get<vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR>().timelineSemaphore;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -354,16 +354,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/32_ecosystem_utilities.cpp
+++ b/attachments/32_ecosystem_utilities.cpp
@@ -353,9 +353,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -367,7 +375,7 @@ class HelloTriangleApplication
 		                        });
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/33_vulkan_profiles.cpp
+++ b/attachments/33_vulkan_profiles.cpp
@@ -361,9 +361,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -375,7 +383,7 @@ class HelloTriangleApplication
 		                        });
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/33_vulkan_profiles.cpp
+++ b/attachments/33_vulkan_profiles.cpp
@@ -362,16 +362,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -487,9 +487,17 @@ class HelloTriangleApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -501,7 +509,7 @@ class HelloTriangleApplication
 		                        });
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/34_android.cpp
+++ b/attachments/34_android.cpp
@@ -488,16 +488,15 @@ class HelloTriangleApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -476,9 +476,17 @@ class VulkanApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -497,7 +505,7 @@ class VulkanApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/35_gltf_ktx.cpp
+++ b/attachments/35_gltf_ktx.cpp
@@ -477,16 +477,15 @@ class VulkanApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -550,16 +550,15 @@ class VulkanApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/36_multiple_objects.cpp
+++ b/attachments/36_multiple_objects.cpp
@@ -549,9 +549,17 @@ class VulkanApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -570,7 +578,7 @@ class VulkanApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/37_multithreading.cpp
+++ b/attachments/37_multithreading.cpp
@@ -593,16 +593,15 @@ class MultithreadedApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();

--- a/attachments/37_multithreading.cpp
+++ b/attachments/37_multithreading.cpp
@@ -592,9 +592,17 @@ class MultithreadedApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -613,7 +621,7 @@ class MultithreadedApplication
 		                                features.template get<vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT>().extendedDynamicState;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -405,9 +405,17 @@ class VulkanRaytracingApplication
 		// Check if the physicalDevice supports the Vulkan 1.3 API version
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
-		// Check if any of the queue families support graphics operations
+		// Check if any of the queue families support both graphics and presentation to our surface
 		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphics = std::ranges::any_of(queueFamilies, [](auto const &qfp) { return !!(qfp.queueFlags & vk::QueueFlagBits::eGraphics); });
+		bool supportsGraphicsAndPresent = false;
+		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
+		{
+			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
+			{
+				supportsGraphicsAndPresent = true;
+				break;
+			}
+		}
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();
@@ -438,7 +446,7 @@ class VulkanRaytracingApplication
 		                                features.template get<vk::PhysicalDeviceRayQueryFeaturesKHR>().rayQuery;
 
 		// Return true if the physicalDevice meets all the criteria
-		return supportsVulkan1_3 && supportsGraphics && supportsAllRequiredExtensions && supportsRequiredFeatures;
+		return supportsVulkan1_3 && supportsGraphicsAndPresent && supportsAllRequiredExtensions && supportsRequiredFeatures;
 	}
 
 	void pickPhysicalDevice()

--- a/attachments/38_ray_tracing.cpp
+++ b/attachments/38_ray_tracing.cpp
@@ -406,16 +406,15 @@ class VulkanRaytracingApplication
 		bool supportsVulkan1_3 = physicalDevice.getProperties().apiVersion >= VK_API_VERSION_1_3;
 
 		// Check if any of the queue families support both graphics and presentation to our surface
-		auto queueFamilies    = physicalDevice.getQueueFamilyProperties();
-		bool supportsGraphicsAndPresent = false;
-		for (uint32_t qfpIndex = 0; qfpIndex < queueFamilies.size(); qfpIndex++)
-		{
-			if ((queueFamilies[qfpIndex].queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface))
-			{
-				supportsGraphicsAndPresent = true;
-				break;
-			}
-		}
+		auto     queueFamilies = physicalDevice.getQueueFamilyProperties();
+		uint32_t qfpIndex      = 0;
+		bool     supportsGraphicsAndPresent =
+		    std::ranges::any_of(queueFamilies,
+		                        [&physicalDevice, &surface = this->surface, &qfpIndex](auto const &qfp) {
+			                        bool const suitable = (qfp.queueFlags & vk::QueueFlagBits::eGraphics) && physicalDevice.getSurfaceSupportKHR(qfpIndex, *surface);
+			                        qfpIndex++;
+			                        return suitable;
+		                        });
 
 		// Check if all required physicalDevice extensions are available
 		auto availableDeviceExtensions = physicalDevice.enumerateDeviceExtensionProperties();


### PR DESCRIPTION
isDeviceSuitable() only checked for a graphics-capable queue family, but createLogicalDevice() later requires one that supports both graphics and presentation. A device could pass suitability and then throw in createLogicalDevice(). Extends the existing search to also require getSurfaceSupportKHR(qfpIndex, *surface), applied consistently across every chapter from window-surface creation onward.

Fixes #457.