### PR TITLE
Minor grammar fix

### DIFF
--- a/en/11_Compute_Shader.adoc
+++ b/en/11_Compute_Shader.adoc
@@ -267,8 +267,8 @@ std::vector<vk::raii::Buffer> shaderStorageBuffers;
 std::vector<vk::raii::DeviceMemory> shaderStorageBuffersMemory;
 ----
 
-In the `createShaderStorageBuffers` we then clear those vectors to clean up
-any objects already created in their as is our RAII practice.
+In the `createShaderStorageBuffers` function, we then clear those vectors to clean up
+any objects already created in there, as is our RAII practice.
 
 [,c++]
 ----


### PR DESCRIPTION
Fixed a minor grammar issue in the "Preparing the shader storage buffers" section of the Compute shader tutorial.


