### PR TITLE
Clarify eErrorLayerNotPresent wording in validation layers chapter

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
@@ -211,9 +211,10 @@ void createInstance()
 }
 ----
 
-If the check was successful then the `vk::raii::Instance` constructor should not
-ever throw a `vk::Result::eErrorLayerNotPresent` error, but you should run the
-program to make sure.
+If the check was successful, the `vk::raii::Instance` constructor should not
+throw a `vk::Result::eErrorLayerNotPresent` error. However, the set of layers
+available on the system can change between the check and the call - or between
+separate runs of the program - so you should still run the program to make sure.
 
 == Message callback
 


### PR DESCRIPTION
The layer set can change between the check and the actual call, so "should not ever throw" was overconfident. Softens the wording.

Fixes #64.