### PR TITLE
Fix parameter naming mismatch and add the filtered debugCallback example

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
@@ -285,8 +285,28 @@ some level of severity, for example:
 
 [,c++]
 ----
-if (messageSeverity >= vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning) {
+if (severity >= vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning) {
     // Message is important enough to show
+}
+----
+
+Applying that to our `debugCallback`, we can filter out anything less severe
+than a warning so that verbose and informational messages don't clutter the
+output:
+
+[,c++]
+----
+static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSeverityFlagBitsEXT       severity,
+                                                      vk::DebugUtilsMessageTypeFlagsEXT              type,
+                                                      const vk::DebugUtilsMessengerCallbackDataEXT * pCallbackData,
+                                                      void *                                         pUserData)
+{
+  if (severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning ||
+      severity == vk::DebugUtilsMessageSeverityFlagBitsEXT::eError) {
+    std::cerr << "validation layer: type " << to_string(type) << " msg: " << pCallbackData->pMessage << std::endl;
+  }
+
+  return vk::False;
 }
 ----
 

--- a/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
+++ b/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.adoc
@@ -310,6 +310,15 @@ static VKAPI_ATTR vk::Bool32 VKAPI_CALL debugCallback(vk::DebugUtilsMessageSever
 }
 ----
 
+Note that `severity` is comparable with `==` here rather than needing a
+bitwise `&`. It's typed as `vk::DebugUtilsMessageSeverityFlagBitsEXT`, not
+`vk::DebugUtilsMessageSeverityFlagsEXT`: the `FlagBits` suffix marks it as an
+enum whose values are individual bits, and Vulkan invokes the callback once
+per severity bit, so `severity` always holds exactly one of those bits on any
+given call. A `Flags` value, by contrast, is a plain integer that can hold
+several `FlagBits` combined together, which is when you'd need `&` to test
+whether one of them is set.
+
 The `messageType` parameter can have the following values:
 
 * `vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral`    : Some event has happened that is unrelated to the specification or performance


### PR DESCRIPTION
Renames messageSeverity to severity to match the actual parameter name, and adds the missing filtered-debugCallback snippet that matches the attachment code.

Fixes #256.